### PR TITLE
docs: correct attribution of 'Asbestos' — it's the upstream name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,17 @@
 > ## 🚀 ARM64 Fork Notice
 >
 > **This repository is a fork of [ish-app/ish](https://github.com/ish-app/ish)** that adds a
-> **native ARM64 threaded-code interpreter** (codename *Asbestos*) for emulating AArch64 Linux
-> on Apple Silicon, alongside the original x86 interpreter (*Jitter*).
+> **native ARM64 guest backend** to upstream iSH's threaded-code interpreter (*Asbestos*,
+> renamed from *jit* upstream in 2024 — [ish-app/ish@d375656f](https://github.com/ish-app/ish/commit/d375656f)).
+> It emulates AArch64 Linux on Apple Silicon, running alongside the original x86 (i386)
+> guest backend.
 >
-> Like upstream's Jitter, Asbestos is not a true JIT — it doesn't emit machine code at
-> runtime. Instead it decodes each guest instruction into a sequence of pointers to
-> pre-compiled ARM64 "gadget" functions that tail-call each other (the same threaded-code
-> technique Forth interpreters use). Because the gadgets are hand-written ARM64 assembly
-> and the guest is ARM64 too, each guest instruction typically costs only a handful of
-> host instructions.
+> Asbestos is **not a JIT** — it doesn't emit machine code at runtime. For each basic block
+> it builds an array of pointers to pre-compiled native "gadget" functions that tail-call
+> each other (the threaded-code technique Forth interpreters use). This fork's contribution
+> is the **ARM64 guest backend** inside that framework: new hand-written ARM64 gadgets that
+> map each AArch64 guest instruction to just a handful of host instructions — same-architecture
+> dispatch, so the overhead per guest instruction is small.
 >
 > **Key enhancements over upstream:**
 > - **Native ARM64 gadget dispatch** — same-architecture, 2-12x faster than x86 for compute

--- a/README_arm64.md
+++ b/README_arm64.md
@@ -2,10 +2,12 @@
 
 **Fork of [ish-app/ish](https://github.com/ish-app/ish)** — a userspace Linux emulator for iOS.
 
-This fork adds a **native ARM64 threaded-code interpreter** (codename *Asbestos*) that emulates
-AArch64 Linux on Apple Silicon, alongside the original x86 interpreter (*Jitter*). The result
-is a dramatically faster and more compatible Linux environment capable of running **Python,
-Node.js, Go, Rust, and native CLI tools** directly on iPhone and iPad.
+This fork adds a **native ARM64 guest backend** to upstream iSH's threaded-code interpreter
+(*Asbestos*, formerly called *jit* — renamed upstream in 2024 because it doesn't actually emit
+machine code). The new backend emulates AArch64 Linux on Apple Silicon, running alongside
+the original x86 (i386) guest backend. The result is a dramatically faster and more
+compatible Linux environment capable of running **Python, Node.js, Go, Rust, and native
+CLI tools** directly on iPhone and iPad.
 
 > ## 🚢 Production Use
 >
@@ -14,13 +16,18 @@ Node.js, Go, Rust, and native CLI tools** directly on iPhone and iPad.
 > on iOS. The numbers and stability claims in this README are grounded in that real-world
 > deployment, not just synthetic benchmarks.
 
-> **Naming note**: Asbestos and upstream Jitter are both *threaded-code interpreters*, not true
-> JITs. Neither emits machine code at runtime — both decode guest instructions into arrays of
-> pointers to pre-compiled native "gadget" functions that tail-call one another (the technique
-> Forth interpreters use). Asbestos's gadgets target ARM64 guests on an ARM64 host, giving
-> near-direct translation; Jitter's gadgets target x86 guests and always cross architectures.
-> Some prose below still says "JIT" as convenient shorthand — read it as "same-arch gadget
-> dispatch," not runtime codegen.
+> **Naming note**: *Asbestos* is the upstream project's name for its threaded-code
+> interpreter (see the upstream commit [`d375656f` "Rename the JIT"](https://github.com/ish-app/ish/commit/d375656f)
+> from June 2024). It is **not a JIT** — neither Asbestos nor its predecessor emits machine
+> code at runtime. For each basic block it builds an array of pointers to pre-compiled
+> native "gadget" functions that tail-call one another (the technique Forth interpreters use).
+>
+> What this fork adds is an **ARM64 guest backend** inside that same Asbestos infrastructure:
+> new gadgets (`asbestos/guest-arm64/gadgets-aarch64/`) that map AArch64 guest instructions
+> to a few ARM64 host instructions each — same-architecture dispatch, so each guest
+> instruction costs only a handful of host instructions. The upstream x86 backend continues
+> to ship unchanged alongside it. Some prose below says "JIT" as convenient shorthand —
+> read it as "same-arch gadget dispatch," not runtime codegen.
 
 ---
 
@@ -74,14 +81,16 @@ fundamental limits:
 
 ## Key Changes from Upstream
 
-### 1. Asbestos — Threaded-Code Interpreter
+### 1. ARM64 Guest Backend inside Asbestos
 
-The core of the ARM64 port. For each guest basic block it builds a **gadget program**: an
-array of `unsigned long` values alternating pointers to pre-compiled ARM64 gadget functions
-with inline operands. Execution is a chain of tail calls — each gadget loads the next pointer
-from the program stream and branches to it (`br x8`). No executable memory is allocated, no
-machine code is generated at runtime. The host-code overhead per guest instruction is a few
-ARM64 instructions inside the corresponding gadget.
+This fork's main contribution. It plugs into upstream Asbestos (the existing threaded-code
+interpreter) and replaces the per-instruction cost model: for each guest basic block the new
+backend builds a **gadget program** — an array of `unsigned long` values alternating pointers
+to pre-compiled ARM64 gadget functions with inline operands. Execution is a chain of tail
+calls — each gadget loads the next pointer from the program stream and branches to it
+(`br x8`). No executable memory is allocated, no machine code is generated at runtime.
+The host-code overhead per guest instruction is a few ARM64 instructions inside the
+corresponding gadget.
 
 **Key files:**
 - `asbestos/asbestos.c` — Block cache, block management, RCU-like jetsam cleanup

--- a/README_arm64_zh.md
+++ b/README_arm64_zh.md
@@ -2,8 +2,9 @@
 
 **Fork 自 [ish-app/ish](https://github.com/ish-app/ish)** — iOS 上的用户态 Linux 模拟器。
 
-本 fork 新增了**原生 ARM64 threaded-code 解释器**（代号 *Asbestos*），可在 Apple Silicon 上模拟
-AArch64 Linux，与原始 x86 解释器（*Jitter*）并存。结果是一个性能和兼容性大幅提升的 Linux 环境,
+本 fork 在上游 iSH 的 threaded-code 解释器（**Asbestos**，2024 年之前叫 *jit*，上游重命名是因为
+它本来就不是真正的 JIT）之上**新增了 ARM64 guest 后端**，在 Apple Silicon 上模拟 AArch64 Linux，
+与原版 x86 (i386) guest 后端并存。结果是一个性能和兼容性大幅提升的 Linux 环境，
 能在 iPhone / iPad 上直接运行 **Python、Node.js、Go、Rust 和原生 CLI 工具**。
 
 > ## 🚢 生产环境使用
@@ -12,11 +13,15 @@ AArch64 Linux，与原始 x86 解释器（*Jitter*）并存。结果是一个性
 > 经过 **10,000+ 用户**在 iOS 上稳定运行 Linux 工具和 shell 负载的真实检验。README 中的性能
 > 数据和稳定性声明均来自这个真实线上部署，而不仅仅是合成基准测试。
 
-> **命名说明**：Asbestos 和上游 Jitter 都是 **threaded-code 解释器**，不是真正的 JIT ——
-> 两者都不在运行时生成机器码，而是把 guest 指令解码成"指向预编译原生 gadget 函数的指针数组"，
-> 各 gadget 通过尾调用衔接（与 Forth 解释器采用相同技术）。Asbestos 的 gadget 处理 ARM64 guest
-> 运行在 ARM64 host（同架构、接近直接翻译），Jitter 的 gadget 处理 x86 guest（总是跨架构）。
-> 下文部分地方仍用 "JIT" 作为简写，请理解为"同架构 gadget 分派"而非运行时代码生成。
+> **命名说明**：*Asbestos* 是上游项目给自家 threaded-code 解释器起的名字（见上游 commit
+> [`d375656f` "Rename the JIT"](https://github.com/ish-app/ish/commit/d375656f)，2024 年 6 月）。
+> 它**不是 JIT** —— Asbestos 及其前身都不会在运行时生成机器码，而是为每个基本块构造一个
+> 指针数组（指向预编译的原生 gadget 函数），各 gadget 通过尾调用衔接（Forth 解释器采用的技术）。
+>
+> 本 fork 所做的是在这个 Asbestos 框架里**新增一个 ARM64 guest 后端**：
+> 新的 gadget（`asbestos/guest-arm64/gadgets-aarch64/`）把 AArch64 guest 指令映射到若干条
+> ARM64 host 指令——同架构分派，每条 guest 指令只需几条 host 指令。上游 x86 后端依然并存。
+> 下文部分地方用 "JIT" 作为简写，请理解为"同架构 gadget 分派"，而非运行时代码生成。
 >
 > 英文版: [README_arm64.md](README_arm64.md)
 
@@ -71,12 +76,13 @@ AArch64 Linux，与原始 x86 解释器（*Jitter*）并存。结果是一个性
 
 ## 相对上游的主要增强
 
-### 1. Asbestos — threaded-code 解释器
+### 1. Asbestos 框架内的 ARM64 guest 后端
 
-ARM64 移植的核心。每个 guest 基本块会被编译成一个 **gadget 程序**：一个 `unsigned long`
-数组，交替存放预编译 ARM64 gadget 函数指针和内联操作数。执行流程是一串尾调用 —— 每个 gadget
-从程序流读取下一条指针并 `br` 跳过去。**不分配可执行内存，不在运行时生成任何机器码**。每条
-guest 指令的 host 指令开销就是对应 gadget 中的几条 ARM64 指令。
+本 fork 的主要贡献。在上游既有的 Asbestos threaded-code 解释器里接入一个 ARM64 guest 后端，
+改写了每条指令的成本模型：每个 guest 基本块被编译成一个 **gadget 程序** —— 一个
+`unsigned long` 数组，交替存放预编译 ARM64 gadget 函数指针和内联操作数。执行流程是一串尾调用 ——
+每个 gadget 从程序流读取下一条指针并 `br` 跳过去。**不分配可执行内存，不在运行时生成任何机器码**。
+每条 guest 指令的 host 指令开销就是对应 gadget 中的几条 ARM64 指令。
 
 **关键文件:**
 - `asbestos/asbestos.c` — 块缓存、块管理、RCU 风格的 jetsam 清理


### PR DESCRIPTION
## Summary

Previously, the README told readers that *Asbestos* was this fork's codename for its ARM64 engine. That is incorrect.

**Asbestos is upstream iSH's own name** for its threaded-code interpreter, introduced in upstream commit [ish-app/ish@d375656f "Rename the JIT"](https://github.com/ish-app/ish/commit/d375656f) (June 2024, author Saagar Jha), which renamed the `jit/` directory to `asbestos/` — specifically because the engine doesn't emit machine code and calling it a JIT was misleading.

This fork's actual contribution is an **ARM64 guest backend inside that existing Asbestos framework** (`asbestos/guest-arm64/` and `asbestos/guest-arm64/gadgets-aarch64/*.S`). The upstream x86 (i386) backend continues to ship unchanged alongside it.

## What changed

- `README.md` — fork notice rewritten: no longer calls Asbestos our codename; links to the upstream rename commit for provenance
- `README_arm64.md` — opening paragraph and "Naming note" corrected; the "Asbestos — Threaded-Code Interpreter" section renamed to "ARM64 Guest Backend inside Asbestos"
- `README_arm64_zh.md` — matching corrections in Chinese

No code, no benchmark data changes — documentation attribution only.

## Test plan

- [x] Three README files render correctly (no garbled chars, links resolve)
- [x] Asbestos upstream rename commit (`d375656f`) verified in the `ish-app/ish` history
- [x] `asbestos/` directory in this fork's tree at fork point already contained the upstream-renamed layout