### PR TITLE
fix stale tlb block cache after exec

### DIFF
--- a/emu/tlb.c
+++ b/emu/tlb.c
@@ -10,17 +10,21 @@ void tlb_refresh(struct tlb *tlb, struct mmu *mmu) {
         return;
     if (tlb->mmu != mmu) {
         // Address space changed (execve); block cache and ret_cache are invalid
-        memset(tlb->block_cache, 0, sizeof(tlb->block_cache));
-        tlb->block_cache_gen = 0;
-        if (tlb->frame != NULL) {
-            free(tlb->frame);
-            tlb->frame = NULL;
-        }
+        tlb_reset_cache(tlb);
     }
     tlb->mmu = mmu;
     tlb->dirty_page = TLB_PAGE_EMPTY;
     tlb->mem_changes = mmu->changes;
     tlb_flush(tlb);
+}
+
+void tlb_reset_cache(struct tlb *tlb) {
+    memset(tlb->block_cache, 0, sizeof(tlb->block_cache));
+    tlb->block_cache_gen = 0;
+    if (tlb->frame != NULL) {
+        free(tlb->frame);
+        tlb->frame = NULL;
+    }
 }
 
 void tlb_flush(struct tlb *tlb) {

--- a/emu/tlb.h
+++ b/emu/tlb.h
@@ -45,6 +45,7 @@ struct tlb {
 #endif
 #define TLB_PAGE_EMPTY 1
 void tlb_refresh(struct tlb *tlb, struct mmu *mmu);
+void tlb_reset_cache(struct tlb *tlb);
 void tlb_free(struct tlb *tlb);
 void tlb_flush(struct tlb *tlb);
 void *tlb_handle_miss(struct tlb *tlb, addr_t addr, int type);

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -219,6 +219,7 @@ static int elf_exec(struct fd *fd, const char *file, struct exec_args argv, stru
     lock(&current->general_lock);
     mm_release(current->mm);
     task_set_mm(current, mm_new());
+    current->tlb_needs_reset = true;
     unlock(&current->general_lock);
     write_wrlock(&current->mem->lock);
 

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -178,6 +178,10 @@ void task_run_current() {
         if (self->mem == NULL) {
             pthread_exit(NULL);
         }
+        if (self->tlb_needs_reset) {
+            tlb_reset_cache(tlb);
+            self->tlb_needs_reset = false;
+        }
         read_wrlock(&self->mem->lock);
         tlb_refresh(tlb, &self->mem->mmu);
         int interrupt = cpu_run_to_interrupt(cpu, tlb);

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -46,6 +46,7 @@ struct task {
     // private
     sigset_t_ saved_mask;
     bool has_saved_mask;
+    bool tlb_needs_reset;
 
     // Set when thread is in a blocking syscall (futex_wait, poll_wait, etc.)
     // Used for deadlock detection: if all threads are blocking, it's a hang.


### PR DESCRIPTION
Add and set flag `tlb_needs_reset` after elf_exec switches to a new mm to clear stale TLB cache before the next execution and prevent stale block reuse after exec.

I discovered this issue while running [byte-unixbench](https://github.com/kdlucas/byte-unixbench). It can be reproduced with `./Run -i 1 -c 8 execl`.