### PR TITLE
replace mm after exec

### DIFF
--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -216,9 +216,13 @@ static int elf_exec(struct fd *fd, const char *file, struct exec_args argv, stru
     // general_lock protects current->mm. otherwise procfs might read the
     // pointer before it's released and then try to lock it after it's
     // released.
+    struct mm *new_mm = mm_new();
+    if (new_mm == NULL)
+        return _ENOMEM;
     lock(&current->general_lock);
-    mm_release(current->mm);
-    task_set_mm(current, mm_new());
+    struct mm *old_mm = current->mm;
+    task_set_mm(current, new_mm);
+    mm_release(old_mm);
     unlock(&current->general_lock);
     write_wrlock(&current->mem->lock);
 


### PR DESCRIPTION
This fixes a stale TLB/JIT cache issue that can occur during `exec`.

I discovered this while running [byte-unixbench](https://github.com/kdlucas/byte-unixbench). 

The issue can be reproduced with:
```bash
./Run -i 1 -c 8 execl
```
In some cases, the allocator can immediately reuse the same address for the new mm/mmu. When that happens, the existing TLB state may incorrectly treat the new memory space as unchanged, leaving stale JIT/TLB cache state alive across exec.

```c
// tlb.c:8
void tlb_refresh(struct tlb *tlb, struct mmu *mmu) {
    if (tlb->mmu == mmu && tlb->mem_changes == mmu->changes) // <-- 1
        return;
    if (tlb->mmu != mmu) { // <-- 2
        // Address space changed (execve); block cache and ret_cache are invalid
        memset(tlb->block_cache, 0, sizeof(tlb->block_cache));
        tlb->block_cache_gen = 0;

// exec.c:219
    lock(&current->general_lock);
    mm_release(current->mm);  // Release First
    task_set_mm(current, mm_new()); // mm_new() may return the same addr as current->mm
    unlock(&current->general_lock);
    write_wrlock(&current->mem->lock);
```