### PR TITLE
xcode(arm64): bump iSH-ARM64 marketing version to 2.0.0

### DIFF
--- a/app/AppARM64.xcconfig
+++ b/app/AppARM64.xcconfig
@@ -6,6 +6,9 @@ PRODUCT_NAME = iSH ARM64
 PRODUCT_BUNDLE_IDENTIFIER = $(ROOT_BUNDLE_IDENTIFIER).arm64
 PRODUCT_APP_GROUP_IDENTIFIER = group.$(ROOT_BUNDLE_IDENTIFIER).arm64
 
+// ARM64 app version, independent of the shared x86 MARKETING_VERSION.
+MARKETING_VERSION = 2.0.0
+
 // Link meson-built libraries directly from the arm64 meson build dir.
 // These are NOT in the Frameworks build phase to prevent Xcode from
 // auto-discovering implicit dependencies on the x86 library targets.

--- a/app/FileProviderARM64.xcconfig
+++ b/app/FileProviderARM64.xcconfig
@@ -14,6 +14,9 @@ SKIP_INSTALL = YES
 PRODUCT_BUNDLE_IDENTIFIER = $(ROOT_BUNDLE_IDENTIFIER).arm64.FileProvider
 PRODUCT_APP_GROUP_IDENTIFIER = group.$(ROOT_BUNDLE_IDENTIFIER).arm64
 
+// Must match the iSH-ARM64 host app version (App Store validation requires it).
+MARKETING_VERSION = 2.0.0
+
 // Header search paths for the FileProvider sources (fs/fake-db.h, kernel/errno.h).
 HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)
 


### PR DESCRIPTION
## Summary
Set the marketing version of the ARM64 app to **2.0.0**, independent of the shared x86 version.

The marketing version is shared across all targets via `Project.xcconfig` (1.3.3). This overrides it to 2.0.0 only for the ARM64 side:

- `AppARM64.xcconfig` → `iSH-ARM64` (and `iSH-ARM64-ffmpeg`, which includes it)
- `FileProviderARM64.xcconfig` → keeps the extension's `CFBundleShortVersionString` in sync with its host app (App Store validation requires the embedded extension and container app to share a version)

The x86 `iSH` / `iSHFileProvider` targets are untouched and remain 1.3.3.

## Verification
`-showBuildSettings` confirms:

| Target | MARKETING_VERSION |
|--------|-------------------|
| iSH-ARM64 | 2.0.0 |
| iSH-ARM64-ffmpeg | 2.0.0 |
| iSHFileProvider-ARM64 | 2.0.0 |
| iSH (x86) | 1.3.3 |
| iSHFileProvider (x86) | 1.3.3 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)