### PR TITLE
fix(ish): three emulation-layer crash fixes (/proc fd readdir, Mach meminfo assert, exit mem UAF)

### DIFF
--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -267,8 +267,13 @@ static struct proc_dir_entry proc_pid_fd;
 
 static bool proc_pid_fd_readdir(struct proc_entry *entry, unsigned long *index, struct proc_entry *next_entry) {
     struct task *task = proc_get_task(entry);
+    // Task exited while its /proc/<pid>/fd dir was being iterated (e.g.
+    // `find /proc` racing short-lived children). This function returns bool —
+    // the old `return _ESRCH` here (-3) read as TRUE, so proc_readdir consumed
+    // a next_entry that was never filled in (meta == NULL) and crashed in
+    // proc_entry_getname (EXC_BAD_ACCESS at 0x10). No task = no more entries.
     if (task == NULL)
-        return _ESRCH;
+        return false;
     lock(&task->files->lock);
     while (*index < task->files->size && task->files->files[*index] == NULL)
         (*index)++;

--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -315,11 +315,22 @@ noreturn void do_exit_group(int status) {
                         sighand_release(task->sighand);
                         task->sighand = NULL;
                     }
-                    if (task->mm != NULL) {
-                        mm_release(task->mm);
-                        task->mm = NULL;
-                        task->mem = NULL;
-                    }
+                    // [T-ish-mem-uaf-user-write] DO NOT mm_release() a stuck
+                    // thread's mm here. This thread is, by definition, still
+                    // running inside an uninterruptible host syscall (e.g. a
+                    // sys_read → user_write blocked on a pipe), and may be about
+                    // to dereference task->mem to copy data back to guest memory.
+                    // Freeing the mm out from under it — as the old code did —
+                    // is a use-after-free: the thread then read_wrlock()s a
+                    // destroyed lock and crashes (EXC_BAD_ACCESS at 0x38 =
+                    // offsetof(struct mem, lock)). Leaving task->mm/task->mem
+                    // intact keeps that access valid; if the thread ever
+                    // unblocks it runs its own do_exit(), which mm_release()s
+                    // correctly. The cost is a leaked mm for a thread that never
+                    // returns — the same "accept the leak, not heap corruption"
+                    // tradeoff this whole safety valve already makes for the
+                    // thread itself. Only the fd table is released so blocked
+                    // pipe readers get EOF (mm_release does not affect that).
                     if (task->files != NULL) {
                         fdtable_release(task->files);
                         task->files = NULL;

--- a/kernel/user.c
+++ b/kernel/user.c
@@ -1,14 +1,31 @@
 #include <string.h>
 #include "kernel/calls.h"
 
-static int __user_read_task(struct task *task, addr_t addr, void *buf, size_t count) {
+// [T-ish-mem-uaf-user-write] Snapshot task->mem once, under an acquire load,
+// and bail if it's NULL. The do_exit_group safety valve can concurrently
+// force-release a stuck sibling's mm and set task->mem = NULL (exit.c). Reading
+// task->mem twice (once for the NULL check, once for the lock) or dereferencing
+// it unguarded races that store — the classic symptom is EXC_BAD_ACCESS at
+// address 0x38 (= offsetof(struct mem, lock)) from read_wrlock(&NULL->lock) or
+// a freed mem. Combined with the A-side fix (the safety valve now leaks the mm
+// instead of freeing it), a non-NULL snapshot here is guaranteed to stay valid
+// for the duration of the copy.
+#define USER_MEM_OR_FAULT(task) ({ \
+    struct mem *_m = __atomic_load_n(&(task)->mem, __ATOMIC_ACQUIRE); \
+    if (_m == NULL) return 1; \
+    _m; \
+})
+
+// [T-ish-mem-uaf-user-write] These take an explicit `mem` snapshot (never read
+// task->mem again inside) so the whole copy runs against one validated mem.
+static int __user_read_mem(struct mem *mem, addr_t addr, void *buf, size_t count) {
     char *cbuf = (char *) buf;
     addr_t p = addr;
     while (p < addr + count) {
         addr_t chunk_end = (PAGE(p) + 1) << PAGE_BITS;
         if (chunk_end > addr + count)
             chunk_end = addr + count;
-        const char *ptr = mem_ptr(task->mem, p, MEM_READ);
+        const char *ptr = mem_ptr(mem, p, MEM_READ);
         if (ptr == NULL)
             return 1;
         memcpy(&cbuf[p - addr], ptr, chunk_end - p);
@@ -17,14 +34,14 @@ static int __user_read_task(struct task *task, addr_t addr, void *buf, size_t co
     return 0;
 }
 
-static int __user_write_task(struct task *task, addr_t addr, const void *buf, size_t count, bool ptrace) {
+static int __user_write_mem(struct mem *mem, addr_t addr, const void *buf, size_t count, bool ptrace) {
     const char *cbuf = (const char *) buf;
     addr_t p = addr;
     while (p < addr + count) {
         addr_t chunk_end = (PAGE(p) + 1) << PAGE_BITS;
         if (chunk_end > addr + count)
             chunk_end = addr + count;
-        char *ptr = mem_ptr(task->mem, p, ptrace ? MEM_WRITE_PTRACE : MEM_WRITE);
+        char *ptr = mem_ptr(mem, p, ptrace ? MEM_WRITE_PTRACE : MEM_WRITE);
         if (ptr == NULL)
             return 1;
         memcpy(ptr, &cbuf[p - addr], chunk_end - p);
@@ -34,9 +51,10 @@ static int __user_write_task(struct task *task, addr_t addr, const void *buf, si
 }
 
 int user_read_task(struct task *task, addr_t addr, void *buf, size_t count) {
-    read_wrlock(&task->mem->lock);
-    int res = __user_read_task(task, addr, buf, count);
-    read_wrunlock(&task->mem->lock);
+    struct mem *mem = USER_MEM_OR_FAULT(task);
+    read_wrlock(&mem->lock);
+    int res = __user_read_mem(mem, addr, buf, count);
+    read_wrunlock(&mem->lock);
     return res;
 }
 
@@ -45,16 +63,18 @@ int user_read(addr_t addr, void *buf, size_t count) {
 }
 
 int user_write_task(struct task *task, addr_t addr, const void *buf, size_t count) {
-    read_wrlock(&task->mem->lock);
-    int res = __user_write_task(task, addr, buf, count, false);
-    read_wrunlock(&task->mem->lock);
+    struct mem *mem = USER_MEM_OR_FAULT(task);
+    read_wrlock(&mem->lock);
+    int res = __user_write_mem(mem, addr, buf, count, false);
+    read_wrunlock(&mem->lock);
     return res;
 }
 
 int user_write_task_ptrace(struct task *task, addr_t addr, const void *buf, size_t count) {
-    read_wrlock(&task->mem->lock);
-    int res = __user_write_task(task, addr, buf, count, true);
-    read_wrunlock(&task->mem->lock);
+    struct mem *mem = USER_MEM_OR_FAULT(task);
+    read_wrlock(&mem->lock);
+    int res = __user_write_mem(mem, addr, buf, count, true);
+    read_wrunlock(&mem->lock);
     return res;
 }
 
@@ -65,33 +85,35 @@ int user_write(addr_t addr, const void *buf, size_t count) {
 int user_read_string(addr_t addr, char *buf, size_t max) {
     if (addr == 0)
         return 1;
-    read_wrlock(&current->mem->lock);
+    struct mem *mem = USER_MEM_OR_FAULT(current);
+    read_wrlock(&mem->lock);
     size_t i = 0;
     while (i < max) {
-        if (__user_read_task(current, addr + i, &buf[i], sizeof(buf[i]))) {
-            read_wrunlock(&current->mem->lock);
+        if (__user_read_mem(mem, addr + i, &buf[i], sizeof(buf[i]))) {
+            read_wrunlock(&mem->lock);
             return 1;
         }
         if (buf[i] == '\0')
             break;
         i++;
     }
-    read_wrunlock(&current->mem->lock);
+    read_wrunlock(&mem->lock);
     return 0;
 }
 
 int user_write_string(addr_t addr, const char *buf) {
     if (addr == 0)
         return 1;
-    read_wrlock(&current->mem->lock);
+    struct mem *mem = USER_MEM_OR_FAULT(current);
+    read_wrlock(&mem->lock);
     size_t i = 0;
     do {
-        if (__user_write_task(current, addr + i, &buf[i], sizeof(buf[i]), false)) {
-            read_wrunlock(&current->mem->lock);
+        if (__user_write_mem(mem, addr + i, &buf[i], sizeof(buf[i]), false)) {
+            read_wrunlock(&mem->lock);
             return 1;
         }
         i++;
     } while (buf[i - 1] != '\0');
-    read_wrunlock(&current->mem->lock);
+    read_wrunlock(&mem->lock);
     return 0;
 }

--- a/platform/darwin.c
+++ b/platform/darwin.c
@@ -2,12 +2,25 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 #include "platform/platform.h"
+#include "debug.h"
+
+// mach_host_self() adds a uref to the host port name on every call; calling it
+// per-read leaks refs and can saturate the name's uref count under guests that
+// poll /proc/meminfo or /proc/stat at high frequency (e.g. node/V8), after
+// which host_info()/host_statistics64() start failing. Resolve it once.
+static host_t cached_host_self(void) {
+    static host_t host = HOST_NULL;
+    if (host == HOST_NULL)
+        host = mach_host_self();
+    return host;
+}
 
 struct cpu_usage get_cpu_usage() {
     host_cpu_load_info_data_t load;
     mach_msg_type_number_t fuck = HOST_CPU_LOAD_INFO_COUNT;
-    host_statistics(mach_host_self(), HOST_CPU_LOAD_INFO, (host_info_t) &load, &fuck);
-    struct cpu_usage usage;
+    struct cpu_usage usage = {};
+    if (host_statistics(cached_host_self(), HOST_CPU_LOAD_INFO, (host_info_t) &load, &fuck) != KERN_SUCCESS)
+        return usage;
     usage.user_ticks = load.cpu_ticks[CPU_STATE_USER];
     usage.system_ticks = load.cpu_ticks[CPU_STATE_SYSTEM];
     usage.idle_ticks = load.cpu_ticks[CPU_STATE_IDLE];
@@ -16,20 +29,43 @@ struct cpu_usage get_cpu_usage() {
 }
 
 struct mem_usage get_mem_usage() {
+    // Last successful reading; served as a fallback so a transient (or
+    // OS-beta-induced) host_info failure degrades /proc/meminfo instead of
+    // aborting the whole app. Benign data race: stale/torn stats are fine here.
+    static struct mem_usage last_good;
+    static bool have_last_good = false;
+
     host_basic_info_data_t basic = {};
     mach_msg_type_number_t fuck = HOST_BASIC_INFO_COUNT;
-    kern_return_t status = host_info(mach_host_self(), HOST_BASIC_INFO, (host_info_t) &basic, &fuck);
-    assert(status == KERN_SUCCESS);
+    kern_return_t status = host_info(cached_host_self(), HOST_BASIC_INFO, (host_info_t) &basic, &fuck);
     vm_statistics64_data_t vm = {};
-    fuck = HOST_VM_INFO64_COUNT;
-    status = host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info_t) &vm, &fuck);
-    assert(status == KERN_SUCCESS);
+    if (status == KERN_SUCCESS) {
+        fuck = HOST_VM_INFO64_COUNT;
+        status = host_statistics64(cached_host_self(), HOST_VM_INFO64, (host_info_t) &vm, &fuck);
+    }
+    if (status != KERN_SUCCESS) {
+        printk("WARNING: get_mem_usage: host_info/host_statistics64 failed (kr=%d), using fallback\n", status);
+        if (have_last_good)
+            return last_good;
+        struct mem_usage fallback = {};
+        uint64_t memsize = 0;
+        size_t size = sizeof(memsize);
+        if (sysctlbyname("hw.memsize", &memsize, &size, NULL, 0) != 0 || memsize == 0)
+            memsize = 4ULL * 1024 * 1024 * 1024;
+        fallback.total = memsize;
+        fallback.free = memsize / 4;
+        fallback.active = memsize / 4;
+        fallback.inactive = memsize / 4;
+        return fallback;
+    }
 
     struct mem_usage usage;
     usage.total = basic.max_mem;
     usage.free = vm.free_count * vm_page_size;
     usage.active = vm.active_count * vm_page_size;
     usage.inactive = vm.inactive_count * vm_page_size;
+    last_good = usage;
+    have_last_good = true;
     return usage;
 }
 


### PR DESCRIPTION
Three crash fixes in the iSH emulation layer, all reproduced from real Minis app crash reports / device logs. Each fix targets an unconditional `abort()`/UAF/OOB-read that took down the whole host app.

## Commits

### `fix(proc)` — /proc/<pid>/fd readdir crash on mid-iteration task exit
`proc_pid_fd_readdir` returns `bool`, but its task-gone guard did `return _ESRCH` (-3) — non-zero, so callers read it as TRUE ("one more entry") while `*next_entry` was never filled in. `proc_readdir` then reached `proc_entry_getname` with `meta == NULL` → `EXC_BAD_ACCESS` at offset 0x10. Triggered by walking `/proc` (`find /`) while short-lived children churn. Same signature recurred in App Store crash reports (`sys_getdents_common` cluster). Fix: `return false` when the task is gone.

### `fix(platform)` — don't abort when Mach host memory stats fail
`get_mem_usage()` asserted `host_info`/`host_statistics64` == `KERN_SUCCESS`; on iOS 27 beta these can fail, and `mach_host_self()` was called per-read (leaking a host-port uref that a `/proc/meminfo`-polling guest like node/V8 can saturate). Either way a guest reading `/proc/meminfo` could abort the app. Fix: cache `mach_host_self()`; replace the asserts with graceful degradation (last-good reading → `sysctl hw.memsize` fallback).

### `fix(kernel)` — mem use-after-free when do_exit_group force-releases a stuck thread's mm
Use-after-free when `do_exit_group` force-releases the `mm` of a thread still blocked in a user-space write.

## Testing
`deps/build_ish.sh` rebuilds libish + host app **BUILD SUCCEEDED** for each fix; the /proc and meminfo fixes were validated against the original device crash logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
