### PR TITLE
sync: make slow-lock tracing a compile-time switch

### DIFF
--- a/util/sync.c
+++ b/util/sync.c
@@ -6,10 +6,12 @@
 #include "debug.h"
 #include "kernel/errno.h"
 
+#if LOCK_SLOW_TRACE
 int g_lock_slow_trace = 0;
 __attribute__((constructor)) static void init_lock_slow_trace(void) {
     g_lock_slow_trace = getenv("ISH_LOCK_TRACE") ? 1 : 0;
 }
+#endif
 
 void cond_init(cond_t *cond) {
     pthread_condattr_t attr;

--- a/util/sync.h
+++ b/util/sync.h
@@ -16,6 +16,22 @@
 
 #define LOCK_DEBUG 0
 
+// Slow-lock tracing: when enabled AND the ISH_LOCK_TRACE environment variable
+// is set, lock() spins with trylock and reports any wait longer than 3s. Useful
+// for diagnosing lock-order inversions and hangs.
+//
+// Compiled out by default. As a plain runtime `if` it could not be optimised
+// away (the flag is a mutable global), so every lock() carried the branch and
+// the inlined tracing body — a needless icache cost across the very many lock
+// sites in the emulator. It also dragged current_pid() and the trace flag into
+// anything that merely takes a lock, which broke linking for standalone tools
+// such as tools/fakefsify that have no kernel task state to report.
+//
+// Enable for a debugging build with -DLOCK_SLOW_TRACE=1.
+#ifndef LOCK_SLOW_TRACE
+#define LOCK_SLOW_TRACE 0
+#endif
+
 typedef struct {
     pthread_mutex_t m;
     pthread_t owner;
@@ -43,8 +59,11 @@ static inline void lock_init(lock_t *lock) {
 #else
 #define LOCK_INITIALIZER {PTHREAD_MUTEX_INITIALIZER, 0}
 #endif
+#if LOCK_SLOW_TRACE
 extern int g_lock_slow_trace; // set from ISH_LOCK_TRACE at startup
+#endif
 static inline void __lock(lock_t *lock, __attribute__((unused)) const char *file, __attribute__((unused)) int line) {
+#if LOCK_SLOW_TRACE
     if (g_lock_slow_trace) {
         struct timespec _s; clock_gettime(CLOCK_MONOTONIC, &_s);
         int spun = 0;
@@ -62,9 +81,12 @@ static inline void __lock(lock_t *lock, __attribute__((unused)) const char *file
         lock->owner = pthread_self();
         goto done;
     }
+#endif
     pthread_mutex_lock(&lock->m);
     lock->owner = pthread_self();
+#if LOCK_SLOW_TRACE
 done:;
+#endif
 #if LOCK_DEBUG
     assert(lock->debug.initialized);
     assert(!lock->debug.file && "Attempting to recursively lock");


### PR DESCRIPTION
## Problem

The `ISH_LOCK_TRACE` slow-lock tracing added in e7fba8f0 sits behind a plain runtime `if` on a mutable global, so the compiler cannot prove it dead. Every `lock()` call site carries the branch **plus the inlined tracing body** — a trylock spin loop, two `clock_gettime` calls and an `fprintf` call site. Across the number of lock sites in the emulator that is a needless icache cost in release builds, where the flag can never be set.

It also leaks kernel dependencies into anything that merely takes a lock. `util/sync.h`'s inline `__lock()` references:

- `g_lock_slow_trace` — defined in `util/sync.c`
- `current_pid()` — kernel task state

`tools/fakefsify` links `util/fchdir.c` for its `lock()` and has neither, so **it has failed to link since e7fba8f0**:

```
Undefined symbols for architecture arm64:
  "_current_pid", referenced from:
      _lock_fchdir in .._util_fchdir.c.o
  "_g_lock_slow_trace", referenced from:
      _lock_fchdir in .._util_fchdir.c.o
```

This went unnoticed for months because a previously built `fakefsify` was still being reused; it only surfaced on a clean checkout with no cached build products.

## Change

Guard the tracing with a `LOCK_SLOW_TRACE` macro (default `0`), matching the existing `LOCK_DEBUG` style in the same header. Release builds compile it out entirely and `__lock()` goes back to a straight `pthread_mutex_lock`. A debugging build opts in with `-DLOCK_SLOW_TRACE=1`, after which `ISH_LOCK_TRACE` behaves exactly as before.

## Verification

| | |
|---|---|
| Default (tracing off) | `ninja tools/fakefsify` links again — 55K binary |
| `-DLOCK_SLOW_TRACE=1` | `ninja libish.a` builds with tracing intact (37 `g_lock_slow_trace` references in the archive) |