### PR TITLE
kernel: host-controlled fork guard hook + path_normalize buffer overflow fix

### DIFF
--- a/fs/path.c
+++ b/fs/path.c
@@ -117,9 +117,21 @@ static int __path_normalize(const char *at_path, const char *path, char *out, in
         return _ENOENT;
 
     if (at_path != NULL && strcmp(at_path, "/") != 0) {
+        // [T-ish-pathnorm-overflow] The base path must leave room for at least
+        // "/x" plus the terminator, or the component loop below writes past
+        // `out`. `n` is signed and every later check is `n == 0`, so a base
+        // that overruns the buffer used to drive `n` NEGATIVE, skipping the
+        // ENAMETOOLONG exit entirely: each iteration then wrote a bare '/'
+        // (line "output a slash" is unconditional) while the name copy was
+        // blocked by `--n > 0`, producing "//" runs that fail
+        // path_is_normalized() — the assert seen in the field — after already
+        // having scribbled past the end of the caller's MAX_PATH buffer.
+        size_t at_len = strlen(at_path);
+        if (at_len + 2 > (size_t) n)
+            return _ENAMETOOLONG;
         strcpy(o, at_path);
-        n -= strlen(at_path);
-        o += strlen(at_path);
+        n -= at_len;
+        o += at_len;
     }
 
     while (*p == '/')
@@ -148,6 +160,13 @@ static int __path_normalize(const char *at_path, const char *path, char *out, in
             }
         }
 
+        // [T-ish-pathnorm-overflow] Bail BEFORE writing the separator when
+        // there is no room for it plus at least one name byte and the NUL.
+        // Previously the slash was written unconditionally and only an exact
+        // `n == 0` was caught afterwards, so an already-exhausted buffer both
+        // overflowed and emitted "//".
+        if (n < 2)
+            return _ENAMETOOLONG;
         // output a slash
         *o++ = '/'; n--;
         char *c = o;
@@ -158,7 +177,10 @@ static int __path_normalize(const char *at_path, const char *path, char *out, in
         while (*p == '/')
             p++;
 
-        if (n == 0)
+        // `<= 0` rather than `== 0`: the loop above can leave n at 0 having
+        // consumed its last byte, and a defensive lower bound keeps a future
+        // accounting slip from sailing past this exit again.
+        if (n <= 0)
             return _ENAMETOOLONG;
 
         if ((flags & N_SYMLINK_FOLLOW) || *p != '\0') {

--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -1,5 +1,6 @@
 #include <time.h>
 #include <stddef.h>
+#include <stdatomic.h>
 #include "debug.h"
 #include "kernel/task.h"
 #include "fs/fd.h"
@@ -16,6 +17,12 @@
 #define CPU_SP(cpu) ((cpu).esp)
 #define CPU_RETVAL(cpu) ((cpu).eax)
 #endif
+
+static _Atomic(ish_fork_guard_t) g_fork_guard = NULL;
+
+void ish_set_fork_guard(ish_fork_guard_t guard) {
+    atomic_store_explicit(&g_fork_guard, guard, memory_order_release);
+}
 
 #define CSIGNAL_ 0x000000ff
 #define CLONE_VM_ 0x00000100
@@ -170,6 +177,21 @@ dword_t sys_clone(dword_t flags, addr_t stack, addr_t ptid, addr_t tls, addr_t c
         return _EINVAL;
     if (flags & CLONE_THREAD_ && !(flags & CLONE_SIGHAND_))
         return _EINVAL;
+
+    // [fork-guard] Let the host layer decide whether to allow this fork. A
+    // negative errno (e.g. _EAGAIN) is returned to the guest verbatim and no
+    // task is created. Threads (CLONE_THREAD_) are exempt: they share the
+    // parent's address space, so they don't add the per-process memory cost
+    // the guard exists to bound, and denying them would break pthread users.
+    if (!(flags & CLONE_THREAD_)) {
+        ish_fork_guard_t guard =
+            atomic_load_explicit(&g_fork_guard, memory_order_acquire);
+        if (guard != NULL) {
+            int err = guard();
+            if (err < 0)
+                return (dword_t) err;
+        }
+    }
 
     struct task *task = task_create_(current);
     if (task == NULL)

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -253,6 +253,14 @@ extern void (*exit_hook)(struct task *task, int code);
 typedef int (*ish_timer_tick_hook_t)(void);
 void ish_set_timer_tick_hook(ish_timer_tick_hook_t hook);
 
+// [fork-guard] Called in sys_clone before a new task is created.
+// Return 0 to allow the fork, or a negative errno (e.g. _EAGAIN) to deny it;
+// the value is returned to the guest verbatim and no task is created.
+// Set with ish_set_fork_guard(); pass NULL to remove. Thread-safe via atomic store.
+// The callback runs on the forking thread and must not allocate or take kernel locks.
+typedef int (*ish_fork_guard_t)(void);
+void ish_set_fork_guard(ish_fork_guard_t guard);
+
 #define superuser() (current != NULL && current->euid == 0)
 
 // Update the thread name to match the current task, in the format "comm-pid".


### PR DESCRIPTION
Two kernel changes that MinisApp has been running against, now proposed for `master`.

## `feat(kernel): ish_set_fork_guard hook` (241e0669)

Exposes one atomic function-pointer hook called from `sys_clone` before
`task_create_`. A host layer can register a callback, check platform-level
resource availability, and return a negative errno (e.g. `_EAGAIN`) to deny the
fork — handed back to the guest verbatim, with no task created.

The kernel carries no platform-specific logic; it only exposes the extension
point. The pattern follows the existing `ish_set_timer_tick_hook` in `calls.c`:
`_Atomic` function pointer, release store / acquire load, `NULL` by default, so
behaviour is unchanged for anyone who never installs a guard.

Placement is after all flag validation but before `task_create_`, so a denial
cannot leak a task or a pid. `CLONE_THREAD_` is deliberately exempt — threads
share the parent's address space, so they don't add the per-process memory cost
a guard would be bounding, and denying them would break pthread users.
`sys_fork` / `sys_vfork` / `sys_clone3` all funnel through `sys_clone`, so this
single point covers every process-creation path.

Motivation: on iOS every guest process lives inside the host app's address
space, so something like `xargs -P 15` over 32 MB Go binaries drives the app
footprint past the Jetsam threshold and the whole app is SIGKILLed. The guard
lets the host cap total memory without hard-coding a process count.

## `fix(ish,path): path_normalize buffer overflow` (d49c092b)

Fixes two TestFlight crashes (2026-08-01, iPhone18,1 / iOS 27.0, reported as
stably reproducible) with identical stacks:

```
__assert_rtn → path_normalize.cold.2 → path_normalize
  → generic_setattrat → sys_truncate64 → handle_interrupt
```

The assert was the symptom, not the bug. `__path_normalize` tracks remaining
space in the signed `int n`, seeded `MAX_PATH - 1`, then reduced by the base
path with no bound check:

```c
n -= strlen(at_path);
```

`sys_truncate64` passes `at = NULL`, so the base is the process CWD. Once the
CWD is long enough that `n` reaches 0 or goes negative, the component loop stops
terminating correctly: the separator write is unconditional while the name copy
is gated by `--n > 0`, and the only exit test was the exact equality `n == 0`.
With `n` already negative that never matches, so each iteration appended a bare
`/` past the end of the caller's `MAX_PATH` buffer, producing `//` runs. The
trailing `assert(path_is_normalized(out))` then fired on the malformed
result — after the memory had already been scribbled over.

Two guards, both returning `_ENAMETOOLONG` (the API contract) rather than
aborting the process:
- reject a base path that doesn't leave room for `"/x"` + NUL before it is
  copied, so `n` can never start ≤ 0;
- bail before writing the separator when `n < 2`, and widen the post-component
  check from `n == 0` to `n <= 0` so an accounting slip can't sail past the exit
  again.

## Verification

- Simulation of the component loop across base / component / depth boundaries:
  every previously-overflowing case now returns `ENAMETOOLONG`, and all valid
  inputs produce byte-identical output to the old code (0 regressions).
- `libish` rebuilt via `deps/build_ish.sh`; app builds clean and was installed
  to device — normal `truncate` still works.
- Merges cleanly into `master` (no overlapping files with `74d6a0df`).

Not verified: the fork-guard hook's denial path has not been exercised on device
in this branch; it is inert unless a host installs a guard.
