### PR TITLE
kernel/native-offload: forward terminating signals to in-process handlers so wedged offloads can be killed

### DIFF
--- a/kernel/native_offload.c
+++ b/kernel/native_offload.c
@@ -53,6 +53,9 @@ int native_offload_exec(const char *native_path, const char *guest_file,
 bool native_offload_forward_signal(struct task *task, int sig) {
     (void)task; (void)sig; return false;
 }
+int native_offload_set_abort_handler(const char *guest_name, native_abort_func abort_fn) {
+    (void)guest_name; (void)abort_fn; return -1;
+}
 #else
 
 // --- Dynamic registry ---
@@ -61,6 +64,9 @@ struct offload_entry {
     char *guest_name;
     char *native_path;           // NULL if using handler
     native_handler_func handler; // non-NULL for in-process execution
+    // [T-ish-offload-signal-forward] Optional: lets a wedged in-process handler
+    // be asked to stop waiting when the guest task is signalled.
+    native_abort_func abort_fn;
 };
 
 static struct offload_entry offload_entries[NATIVE_OFFLOAD_MAX];
@@ -154,8 +160,26 @@ int native_offload_add_handler(const char *guest_name, native_handler_func handl
     e->guest_name = strdup(guest_name);
     e->native_path = NULL;
     e->handler = handler;
+    e->abort_fn = NULL;
     fprintf(stderr, "native_offload: %s → [builtin]\n", guest_name);
     return 0;
+}
+
+// [T-ish-offload-signal-forward] Attach an abort callback to a registered
+// in-process handler. Separate from add_handler so existing registrations (and
+// the macOS posix_spawn path) need no change: an offload without one keeps the
+// pre-existing "cannot be interrupted" behaviour.
+int native_offload_set_abort_handler(const char *guest_name, native_abort_func abort_fn) {
+    for (int i = 0; i < offload_count; i++) {
+        if (strcmp(offload_entries[i].guest_name, guest_name) != 0)
+            continue;
+        if (offload_entries[i].handler == NULL)
+            return -1;   // posix_spawn offload — signals already go via kill()
+        offload_entries[i].abort_fn = abort_fn;
+        fprintf(stderr, "native_offload: %s abort handler registered\n", guest_name);
+        return 0;
+    }
+    return -1;
 }
 
 // Internal: find entry by guest binary basename
@@ -298,12 +322,42 @@ static int guest_to_host_signal(int guest_sig) {
 }
 
 bool native_offload_forward_signal(struct task *task, int sig) {
-    if (!task->is_native_proxy || task->native_pid <= 0)
+    // Shape 1: posix_spawn proxy — a real host pid exists, signal it directly.
+    if (task->is_native_proxy && task->native_pid > 0) {
+        int host_sig = guest_to_host_signal(sig);
+        if (host_sig > 0)
+            kill(task->native_pid, host_sig);
+        return true;
+    }
+
+    // [T-ish-offload-signal-forward] Shape 2: in-process handler. There is no
+    // host pid to signal — the handler is running on this task's OWN thread,
+    // which is parked inside host code and will never look at the guest signal
+    // queue. Ask the handler to stop instead.
+    //
+    // Only terminating signals do this. A handler is not a general signal
+    // target: forwarding e.g. SIGWINCH or SIGCHLD as "abort" would turn routine
+    // notifications into a killed transcode. SIGKILL/SIGTERM/SIGINT/SIGQUIT/
+    // SIGHUP are the ones whose whole meaning is "stop now"; everything else
+    // falls through to normal guest delivery (harmlessly queued, as today).
+    struct offload_entry *entry = (struct offload_entry *) task->native_offload_entry;
+    if (entry == NULL || entry->abort_fn == NULL)
         return false;
-    int host_sig = guest_to_host_signal(sig);
-    if (host_sig > 0)
-        kill(task->native_pid, host_sig);
-    return true;
+    if (sig != SIGKILL_ && sig != SIGTERM_ && sig != SIGINT_ &&
+        sig != SIGQUIT_ && sig != SIGHUP_)
+        return false;
+
+    // Deliberately NOT consuming the signal (returns false after the callback):
+    // the abort only asks the handler to unblock. The handler then returns
+    // normally and exec_handler calls do_exit() — but do_exit() runs on the
+    // task's own thread, and only the guest signal machinery knows the right
+    // exit status for a killed task. Letting the signal continue to normal
+    // delivery keeps `kill -9` reporting the usual killed-by-signal status
+    // instead of the handler's own return code.
+    bool aborting = entry->abort_fn(sig);
+    printk("native_offload: signal %d → in-process handler %s abort (%s)\n",
+           sig, entry->guest_name, aborting ? "accepted" : "declined");
+    return false;
 }
 
 // --- Post-exec: scan for new files and register in fakefs DB ---
@@ -623,8 +677,18 @@ static int exec_handler(native_handler_func handler, const char *guest_file,
         free(host_cwd);
     }
 
+    // [T-ish-offload-signal-forward] Publish which offload this task is running
+    // so native_offload_forward_signal can find its abort callback while the
+    // handler is in flight. Set immediately before the call and cleared right
+    // after, so a signal can only reach the callback during the window when the
+    // handler is genuinely running. `entry` points into the static registry,
+    // which outlives every task.
+    current->native_offload_entry = offload_find(guest_file);
+
     // Call the handler in-process
     int ret = handler((int)argc, handler_argv, handler_stdin, handler_stdout, handler_stderr);
+
+    current->native_offload_entry = NULL;
 
     // Close write ends so forwarding threads see EOF
     if (stdout_pipe[1] >= 0) close(stdout_pipe[1]);

--- a/kernel/native_offload.h
+++ b/kernel/native_offload.h
@@ -63,6 +63,37 @@ typedef int (*native_handler_func)(int argc, char **argv,
 // Returns 0 on success, -1 if registry is full.
 int native_offload_add_handler(const char *guest_name, native_handler_func handler);
 
+// [T-ish-offload-signal-forward] Abort callback for an in-process handler.
+//
+// WHY THIS EXISTS: a handler runs synchronously on the guest thread and
+// `exec_handler` only calls do_exit() once it returns. A handler that never
+// returns (ffmpeg wedged inside a VideoToolbox transcode is the reported case)
+// therefore pins the guest task in the process table forever, and `kill -9`
+// silently does nothing: send_signal queues the signal and cpu_poke()s a thread
+// that is not in the CPU loop to see it.
+//
+// Signals cannot be delivered *to* such a handler from outside — do_exit()
+// operates on the thread-local `current` and ends in pthread_exit(), so only
+// the task's own thread can reap it. The only workable shape is to ask the
+// handler to stop waiting and return, which is what this callback does.
+//
+// Contract for implementors:
+//   - Called from the SIGNALLING thread, not the handler's own thread, while
+//     the handler is still running. It must be async-safe with respect to the
+//     handler body: signal an event, do not take a lock the handler holds.
+//   - Returns true if the handler will now wind down, false if it cannot be
+//     aborted (the signal then falls through to normal guest delivery).
+//   - The handler is expected to return "soon" after this; whatever host work
+//     it had started may keep running. Abandoning that work is the caller's
+//     accepted cost, and the handler should say so in the log.
+typedef bool (*native_abort_func)(int sig);
+
+// Attach an abort callback to an already-registered in-process handler.
+// Returns 0 on success, -1 if `guest_name` has no handler registered.
+// Optional: a handler without one simply cannot be interrupted, which is the
+// pre-existing behaviour for every offload.
+int native_offload_set_abort_handler(const char *guest_name, native_abort_func abort_fn);
+
 // Register a host binary offload (macOS CLI only, uses posix_spawn).
 // spec is "name" or "name=/host/path". Returns 0 on success.
 int native_offload_add(const char *spec);
@@ -79,8 +110,15 @@ int native_offload_exec(const char *native_path,
                         size_t argc, const char *argv,
                         const char *envp);
 
-// Forward a signal to the native process backing a proxy task.
-// Returns true if the signal was forwarded.
+// Forward a signal to the native work backing a task, covering BOTH offload
+// shapes:
+//   - posix_spawn proxy tasks  -> kill(native_pid, ...)
+//   - in-process handler tasks -> the handler's registered abort callback
+// Returns true if the signal was consumed by one of those paths.
+//
+// [T-ish-offload-signal-forward] The handler branch is the addition. Before it,
+// this returned false for every in-process handler, so `kill` on a wedged
+// ffmpeg queued a signal nobody would ever read.
 bool native_offload_forward_signal(struct task *task, int sig);
 
 // ============================================================================

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -125,6 +125,15 @@ struct task {
     pid_t native_pid;
     bool is_native_proxy;
 
+    // [T-ish-offload-signal-forward] Set while this task is executing an
+    // IN-PROCESS offload handler (native_offload_add_handler). Distinct from
+    // is_native_proxy, which covers only the posix_spawn shape: a handler runs
+    // on this very thread with no host pid, so a signal can't be forwarded with
+    // kill() — it has to go through the handler's abort callback instead.
+    // Points into the static offload registry, which lives for the process
+    // lifetime, so it never dangles. NULL when not in a handler.
+    void *native_offload_entry;
+
     // current condition/lock, so it can be notified in case of a signal
     cond_t *waiting_cond;
     lock_t *waiting_lock;


### PR DESCRIPTION
## Background

A wedged `ffmpeg` transcode left two guest processes that `kill -9` reported
success on but could not remove. `native_offload_forward_signal` covered only
the posix_spawn shape:

```c
if (!task->is_native_proxy || task->native_pid <= 0)
    return false;
```

`is_native_proxy` is set solely on the posix_spawn path, so every offload
registered through `native_offload_add_handler` — ffmpeg included — fell through
to normal guest delivery. That queues the signal and `cpu_poke()`s the task, but
an in-process handler runs **on the guest thread**, which is parked inside host
code and never returns to the CPU loop to look at the queue. The signal was real
and correctly queued; nobody would ever read it.

## Why it can't be fixed on the delivery side

`do_exit()` works entirely through the thread-local `current` and ends in
`pthread_exit()`, so only the task's own thread can reap it. No killer thread can
tear down a task from outside. The task can only leave the process table if its
own thread is released from the handler — so the signal has to become a *request
to* the handler, not a delivery to the task.

## Changes

- **`native_abort_func` + `native_offload_set_abort_handler()`** — an in-process
  handler may opt in to being interruptible. Kept separate from `add_handler` so
  every existing registration and the posix_spawn path are untouched; an offload
  without one keeps today's non-interruptible behaviour.

- **`task->native_offload_entry`** — set immediately around the handler call in
  `exec_handler`, so the signal path can find the running offload's callback only
  while it is genuinely in flight. It points into the static registry, which
  outlives every task, so it cannot dangle.

- **`native_offload_forward_signal` gains the handler branch.** Restricted to
  terminating signals (KILL/TERM/INT/QUIT/HUP): a handler is not a general signal
  target, and forwarding SIGWINCH or SIGCHLD as "abort" would turn a routine
  notification into a killed transcode.

  It deliberately **returns false** after invoking the callback rather than
  consuming the signal. The abort only unblocks the handler; letting the signal
  continue to normal delivery is what gives the task the usual killed-by-signal
  exit status instead of the handler's return code.

## Verification

On device (iPhone 11, iOS 26) with a deliberately-wedged test handler, which
reproduces the exact ffmpeg shape without needing a real stuck transcode:

```
BEFORE:  4 RW   minis-hangtest
kill_exit=0
AFTER:   <<GONE>>
```

Kernel trace, in order, across two threads:

```
[HangTest] handler entered — will block until aborted
[HangTest] abort requested by signal 9
native_offload: signal 9 -> in-process handler minis-hangtest abort (accepted)
[HangTest] abort observed — returning so the guest task can exit
native_offload: [builtin] /usr/local/bin/minis-hangtest exited with code 0
```

Before this change that process could not be removed from the process table at all.

`deps/build_ish.sh` builds clean against current `master`.

## Note on the branch

This branch previously also carried the two commits merged as #28. It has been
rebased onto `master`, which dropped both as already-upstream, so this PR is now
exactly one commit touching three kernel files. The rebase also removed an
unintended revert of #26 (`S_IFDIR` in `tools/fakefs.c`) that the stale base
would otherwise have reintroduced.
