### PR TITLE
fix(arm64): kernel/fs correctness batch — ASIMD FCVT, wait semantics, O_NOFOLLOW/O_DIRECTORY, pids_lock leak

### DIFF
--- a/asbestos/guest-arm64/gadgets-aarch64/math.S
+++ b/asbestos/guest-arm64/gadgets-aarch64/math.S
@@ -16205,3 +16205,125 @@ make_widening_accum umlsl, umlsl
     str d0, [x14]
     str xzr, [x14, #8]
     gret
+
+// ---------------------------------------------------------------------------
+// AdvSIMD vector floating-point lane narrow/widen conversions.
+//
+// FCVTN/FCVTN2, FCVTL/FCVTL2, FCVTXN/FCVTXN2 are mandatory ARMv8.0-A Advanced
+// SIMD instructions and iSH advertises `asimd`, but they had no gadget, so any
+// guest executing one was killed (numpy's float64<->float32 .astype() hits
+// them). The host is AArch64 and has these instructions natively, so each
+// gadget is the host instruction plus the lane placement the encoding asks for.
+//
+// Operand word laid out by gen.c: rd | rn<<8 | sz<<16 | Q<<24
+//   sz: for N/XN the source precision, for L the destination precision
+//       (0 = half<->single, 1 = single<->double)
+//   Q:  the "2" variant. FCVTN2/FCVTXN2 write the high 64 bits and preserve
+//       the low ones; FCVTL2 reads the high 64 bits of the source.
+// ---------------------------------------------------------------------------
+
+// FCVTN Vd.<Tb>, Vn.<Ta>  /  FCVTN2 Vd.<Tb>, Vn.<Ta>
+//   sz=0: 4S -> 4H,  sz=1: 2D -> 2S
+.gadget fcvtn_vec
+    ldr x8, [_pc]
+    add _pc, _pc, #8
+    and x9, x8, #0x1f       // rd
+    ubfx x10, x8, #8, #5    // rn
+    ubfx x11, x8, #16, #1   // sz
+    ubfx x17, x8, #24, #1   // Q ("2" variant)
+
+    add x13, _cpu, #CPU_fp
+    lsl x14, x9, #4
+    add x14, x13, x14       // &Vd
+    lsl x15, x10, #4
+    add x15, x13, x15       // &Vn
+
+    ldr q0, [x15]
+    cbnz x17, .Lfcvtn_high
+    // Q=0: result in the low 64 bits, upper half zeroed.
+    cbnz x11, .Lfcvtn_low_d
+    fcvtn v0.4h, v0.4s
+    b .Lfcvtn_low_store
+.Lfcvtn_low_d:
+    fcvtn v0.2s, v0.2d
+.Lfcvtn_low_store:
+    str d0, [x14]
+    str xzr, [x14, #8]
+    gret
+.Lfcvtn_high:
+    // Q=1: narrow into the high 64 bits, low half of Vd preserved. Load Vd
+    // first so the host FCVTN2 keeps exactly the bits the guest expects.
+    ldr q1, [x14]
+    cbnz x11, .Lfcvtn_high_d
+    fcvtn2 v1.8h, v0.4s
+    b .Lfcvtn_high_store
+.Lfcvtn_high_d:
+    fcvtn2 v1.4s, v0.2d
+.Lfcvtn_high_store:
+    str q1, [x14]
+    gret
+
+// FCVTL Vd.<Ta>, Vn.<Tb>  /  FCVTL2 Vd.<Ta>, Vn.<Tb>
+//   sz=0: 4H -> 4S,  sz=1: 2S -> 2D
+.gadget fcvtl_vec
+    ldr x8, [_pc]
+    add _pc, _pc, #8
+    and x9, x8, #0x1f
+    ubfx x10, x8, #8, #5
+    ubfx x11, x8, #16, #1   // sz
+    ubfx x17, x8, #24, #1   // Q ("2" variant: read the high half)
+
+    add x13, _cpu, #CPU_fp
+    lsl x14, x9, #4
+    add x14, x13, x14
+    lsl x15, x10, #4
+    add x15, x13, x15
+
+    ldr q0, [x15]
+    cbnz x17, .Lfcvtl_high
+    // Q=0: widen the low 64 bits.
+    cbnz x11, .Lfcvtl_low_d
+    fcvtl v0.4s, v0.4h
+    b .Lfcvtl_store
+.Lfcvtl_low_d:
+    fcvtl v0.2d, v0.2s
+    b .Lfcvtl_store
+.Lfcvtl_high:
+    // Q=1: widen the high 64 bits.
+    cbnz x11, .Lfcvtl_high_d
+    fcvtl2 v0.4s, v0.8h
+    b .Lfcvtl_store
+.Lfcvtl_high_d:
+    fcvtl2 v0.2d, v0.4s
+.Lfcvtl_store:
+    // The result is always a full 128-bit vector.
+    str q0, [x14]
+    gret
+
+// FCVTXN Vd.2s, Vn.2d  /  FCVTXN2 Vd.4s, Vn.2d
+//   Narrow double->single using round-to-odd. Only sz=1 is defined; gen.c
+//   rejects sz=0 before reaching here.
+.gadget fcvtxn_vec
+    ldr x8, [_pc]
+    add _pc, _pc, #8
+    and x9, x8, #0x1f
+    ubfx x10, x8, #8, #5
+    ubfx x17, x8, #24, #1   // Q ("2" variant)
+
+    add x13, _cpu, #CPU_fp
+    lsl x14, x9, #4
+    add x14, x13, x14
+    lsl x15, x10, #4
+    add x15, x13, x15
+
+    ldr q0, [x15]
+    cbnz x17, .Lfcvtxn_high
+    fcvtxn v0.2s, v0.2d
+    str d0, [x14]
+    str xzr, [x14, #8]
+    gret
+.Lfcvtxn_high:
+    ldr q1, [x14]
+    fcvtxn2 v1.4s, v0.2d
+    str q1, [x14]
+    gret

--- a/asbestos/guest-arm64/gen.c
+++ b/asbestos/guest-arm64/gen.c
@@ -552,6 +552,9 @@ extern void gadget_fcvtps_int_vec(void);   // FCVTPS (toward +inf, signed)
 extern void gadget_fcvtpu_int_vec(void);   // FCVTPU (toward +inf, unsigned)
 extern void gadget_fcvtas_int_vec(void);   // FCVTAS (ties away, signed)
 extern void gadget_fcvtau_int_vec(void);   // FCVTAU (ties away, unsigned)
+extern void gadget_fcvtn_vec(void);        // FCVTN/FCVTN2 (narrow: 4S->4H, 2D->2S)
+extern void gadget_fcvtl_vec(void);        // FCVTL/FCVTL2 (widen: 4H->4S, 2S->2D)
+extern void gadget_fcvtxn_vec(void);       // FCVTXN/FCVTXN2 (narrow 2D->2S, round to odd)
 extern void gadget_frintn_vec_vec(void);   // FRINTN (round to nearest, ties to even)
 extern void gadget_frinta_vec_vec(void);   // FRINTA (round to nearest, ties away)
 extern void gadget_frintp_vec_vec(void);   // FRINTP (round toward +inf)
@@ -5503,6 +5506,42 @@ skip_three_different:
         gen(state, (unsigned long) gadget_rbit_vec);
         gen(state, rd | (rn << 8) | (Q << 16));
         return 1;
+    }
+
+    // AdvSIMD vector FP lane narrow/widen: FCVTN{2}, FCVTL{2}, FCVTXN{2}
+    // Format: 0 Q U 01110 sz 10000 opcode 10 Rn Rd, opcode 0x16 (N) / 0x17 (L, XN)
+    // These are handled before the generic two-register-misc block below because
+    // that block rejects sz=1 with Q=0, which is legal for all three of these
+    // (FCVTN Vd.2s, FCVTL Vd.2d and FCVTXN Vd.2s are all Q=0 forms).
+    if ((insn & 0xbfbff800) == 0x0e216800 ||   // FCVTN{2}   (U=0, opcode 0x16)
+        (insn & 0xbfbff800) == 0x0e217800 ||   // FCVTL{2}   (U=0, opcode 0x17)
+        (insn & 0xbfbff800) == 0x2e216800) {   // FCVTXN{2}  (U=1, opcode 0x16)
+        uint32_t Q = (insn >> 30) & 1;
+        uint32_t U = (insn >> 29) & 1;
+        uint32_t opcode = (insn >> 12) & 0x1f;
+        uint32_t sz = (insn >> 22) & 1;
+        uint32_t rn = (insn >> 5) & 0x1f;
+        uint32_t rd = insn & 0x1f;
+
+        void *gadget = NULL;
+        if (opcode == 0x16 && U == 0) {
+            gadget = gadget_fcvtn_vec;
+        } else if (opcode == 0x17 && U == 0) {
+            gadget = gadget_fcvtl_vec;
+        } else if (opcode == 0x16 && U == 1) {
+            // FCVTXN only narrows double->single; sz=0 is unallocated.
+            if (sz == 0) {
+                gen_interrupt(state, INT_UNDEFINED);
+                return 0;
+            }
+            gadget = gadget_fcvtxn_vec;
+        }
+
+        if (gadget) {
+            gen(state, (unsigned long) gadget);
+            gen(state, rd | (rn << 8) | (sz << 16) | (Q << 24));
+            return 1;
+        }
     }
 
     // AdvSIMD two-register misc: FP conversions, rounding, unary, compare-with-zero

--- a/bench-legacy/scripts/test_200_core_software.sh
+++ b/bench-legacy/scripts/test_200_core_software.sh
@@ -1,0 +1,640 @@
+#!/bin/bash
+
+# iSH ARM64 核心软件全面测试 (200+ 软件)
+# 自动安装缺失的包
+
+BENCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ISH_ROOT="$(dirname "$BENCH_DIR")"
+ISH="$ISH_ROOT/build-arm64-release/ish -f $ISH_ROOT/alpine-arm64-fakefs /bin/sh -c"
+REPORT="$BENCH_DIR/reports/core_200_test_$(date +%Y%m%d_%H%M%S).md"
+
+mkdir -p "$BENCH_DIR/reports"
+
+echo "# iSH ARM64 200+ 核心软件测试报告" | tee "$REPORT"
+echo "" | tee -a "$REPORT"
+echo "**测试日期**: $(date '+%Y-%m-%d %H:%M:%S')" | tee -a "$REPORT"
+echo "**目标**: 测试 200+ 核心软件功能 (自动安装缺失包)" | tee -a "$REPORT"
+echo "" | tee -a "$REPORT"
+
+TOTAL=0
+PASS=0
+FAIL=0
+INSTALLED_PKGS=""
+
+# Binary → Alpine package mapping
+declare -A PKG_MAP=(
+    # 文件工具
+    [file]="file"
+    [xz]="xz"
+    [unxz]="xz"
+    [zstd]="zstd"
+    # 文本工具
+    [fmt]="coreutils"
+    [column]="util-linux"
+    [base32]="coreutils"
+    [numfmt]="coreutils"
+    # 编译工具链
+    [cc]="build-base"
+    [c++]="build-base"
+    [cpp]="gcc"
+    [make]="make"
+    [clang]="clang"
+    [go]="go"
+    [m4]="m4"
+    [ld]="binutils"
+    [as]="binutils"
+    [ar]="binutils"
+    [ranlib]="binutils"
+    [nm]="binutils"
+    [objdump]="binutils"
+    [objcopy]="binutils"
+    [strip]="binutils"
+    [size]="binutils"
+    [pkg-config]="pkgconf"
+    # 编辑器
+    [bash]="bash"
+    [nano]="nano"
+    [ed]="ed"
+    # 数据库
+    [sqlite3]="sqlite"
+    # 多媒体
+    [convert]="imagemagick"
+    [identify]="imagemagick"
+    [mogrify]="imagemagick"
+    [gm]="graphicsmagick"
+    # 安全
+    [gpg]="gnupg"
+    # 版本控制
+    [hg]="mercurial"
+    # 调试
+    [gdb]="gdb"
+    [ldd]="libc-utils"
+    [lsof]="lsof"
+)
+
+install_pkg() {
+    local pkg=$1
+    # Skip if already installed this session
+    if echo "$INSTALLED_PKGS" | grep -qw "$pkg"; then
+        return 0
+    fi
+    echo "  -> Installing $pkg ..."
+    $ISH "apk add --no-cache $pkg" >/dev/null 2>&1
+    local ret=$?
+    INSTALLED_PKGS="$INSTALLED_PKGS $pkg"
+    return $ret
+}
+
+# Ensure binary exists, install if missing
+ensure_binary() {
+    local binary=$1
+    # Check if binary exists in guest
+    $ISH "which $binary >/dev/null 2>&1 || test -x /usr/bin/$binary || test -x /usr/local/bin/$binary" >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        local pkg="${PKG_MAP[$binary]}"
+        if [ -n "$pkg" ]; then
+            install_pkg "$pkg"
+        fi
+    fi
+}
+
+test_software() {
+    local category=$1
+    local name=$2
+    local cmd=$3
+    local expect=$4
+    local binary=$5  # optional: binary to ensure installed
+
+    TOTAL=$((TOTAL + 1))
+
+    # Auto-install if binary specified
+    if [ -n "$binary" ]; then
+        ensure_binary "$binary"
+    fi
+
+    output=$($ISH "$cmd" 2>&1)
+    exit_code=$?
+
+    local status="FAIL"
+    local icon="x"
+
+    if [ -n "$expect" ]; then
+        if echo "$output" | grep -qi "$expect"; then
+            icon="ok"
+            status="PASS"
+            PASS=$((PASS + 1))
+        else
+            FAIL=$((FAIL + 1))
+        fi
+    elif [ $exit_code -eq 0 ]; then
+        icon="ok"
+        status="PASS"
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+    fi
+
+    if [ "$icon" = "ok" ]; then
+        printf "| %-20s | %-60s | PASS |\n" "$name" "$cmd" | tee -a "$REPORT"
+    else
+        printf "| %-20s | %-60s | FAIL |\n" "$name" "$cmd" | tee -a "$REPORT"
+    fi
+}
+
+section_header() {
+    echo "" | tee -a "$REPORT"
+    echo "## $1" | tee -a "$REPORT"
+    echo "| Software | Test Command | Status |" | tee -a "$REPORT"
+    echo "|----------|-------------|--------|" | tee -a "$REPORT"
+}
+
+# ============================================================
+# Pre-install: batch install all missing packages at once
+# ============================================================
+echo "Checking and installing missing packages..." | tee -a "$REPORT"
+PKGS_TO_INSTALL=""
+check_and_add() {
+    local binary=$1
+    local pkg=$2
+    $ISH "which $binary >/dev/null 2>&1" >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        if ! echo "$PKGS_TO_INSTALL" | grep -qw "$pkg"; then
+            PKGS_TO_INSTALL="$PKGS_TO_INSTALL $pkg"
+        fi
+    fi
+}
+
+check_and_add file file
+check_and_add xz xz
+check_and_add zstd zstd
+check_and_add fmt coreutils
+check_and_add column util-linux
+check_and_add base32 coreutils
+check_and_add numfmt coreutils
+check_and_add cc build-base
+check_and_add make make
+check_and_add m4 m4
+check_and_add ld binutils
+check_and_add pkg-config pkgconf
+check_and_add clang clang
+check_and_add go go
+check_and_add bash bash
+check_and_add nano nano
+check_and_add ed ed
+check_and_add sqlite3 sqlite
+check_and_add convert imagemagick
+check_and_add gm graphicsmagick
+check_and_add gpg gnupg
+check_and_add hg mercurial
+check_and_add gdb gdb
+check_and_add php php
+check_and_add ruby ruby
+check_and_add perl perl
+check_and_add lua5.4 lua5.4
+check_and_add dig bind-tools
+check_and_add git git
+check_and_add openssl openssl
+check_and_add jq jq
+
+if [ -n "$PKGS_TO_INSTALL" ]; then
+    echo "Installing:$PKGS_TO_INSTALL" | tee -a "$REPORT"
+    $ISH "apk add --no-cache $PKGS_TO_INSTALL" 2>&1 | tail -3
+    echo "" | tee -a "$REPORT"
+else
+    echo "All packages already installed." | tee -a "$REPORT"
+    echo "" | tee -a "$REPORT"
+fi
+
+# ============================================================
+# 1. 基础系统工具 (30+)
+# ============================================================
+section_header "1. Basic System Tools (31)"
+
+test_software "系统" "BusyBox" "busybox --help" "BusyBox"
+test_software "系统" "ls" "ls /" "bin"
+test_software "系统" "cat" "cat /etc/os-release" "Alpine"
+test_software "系统" "echo" "echo 'test'" "test"
+test_software "系统" "grep" "echo 'test' | busybox grep test" "test"
+test_software "系统" "sed" "echo 'test' | sed 's/test/ok/'" "ok"
+test_software "系统" "awk" "echo '1 2' | awk '{print \$1+\$2}'" "3"
+test_software "系统" "wc" "echo 'a b c' | wc -w" "3"
+test_software "系统" "sort" "echo -e '3\n1\n2' | sort | head -1" "1"
+test_software "系统" "uniq" "echo -e 'a\na\nb' | uniq | wc -l" "2"
+test_software "系统" "head" "echo -e '1\n2\n3' | head -1" "1"
+test_software "系统" "tail" "echo -e '1\n2\n3' | tail -1" "3"
+test_software "系统" "cut" "echo 'a:b:c' | cut -d: -f2" "b"
+test_software "系统" "paste" "echo '1' > /tmp/a && echo '2' > /tmp/b && paste /tmp/a /tmp/b | grep '1'" "1"
+test_software "系统" "tr" "echo 'abc' | tr 'a-z' 'A-Z'" "ABC"
+test_software "系统" "tee" "echo 'test' | tee /tmp/tee.txt | grep test" "test"
+test_software "系统" "xargs" "echo 'test' | xargs echo" "test"
+test_software "系统" "find" "find /etc -name 'alpine-release' -type f" "alpine-release"
+test_software "系统" "which" "which sh" "sh"
+test_software "系统" "whoami" "whoami" ""
+test_software "系统" "pwd" "pwd" "/"
+test_software "系统" "basename" "basename /usr/bin/test" "test"
+test_software "系统" "dirname" "dirname /usr/bin/test" "/usr/bin"
+test_software "系统" "date" "date" ""
+test_software "系统" "sleep" "sleep 0.1 && echo ok" "ok"
+test_software "系统" "yes" "yes | head -1" "y"
+test_software "系统" "seq" "seq 3 | wc -l" "3"
+test_software "系统" "expr" "expr 2 + 2" "4"
+test_software "系统" "test" "test 1 -eq 1 && echo ok" "ok"
+test_software "系统" "env" "env | grep -c PATH" "1"
+test_software "系统" "printenv" "printenv PATH" ""
+
+# ============================================================
+# 2. 文件操作工具 (25+)
+# ============================================================
+section_header "2. File Operations (26)"
+
+test_software "文件" "cp" "rm -f /tmp/src /tmp/dst && echo 'test' > /tmp/src && cp /tmp/src /tmp/dst && cat /tmp/dst" "test"
+# Regression (#30/#31): cp onto a destination that ALREADY EXISTS. The case
+# above copies to a new path and passes even with the bug. GNU cp probes an
+# existing destination with open(dst, O_PATH|O_DIRECTORY) and compares
+# (st_dev, st_ino) across stat/fstat; with the old O_DIRECTORY value it decided
+# dst was a directory and failed with "cannot create regular file
+# '/tmp/cp_overwrite_dst/cp_overwrite_src': Not a directory".
+test_software "文件" "cp-overwrite" "rm -f /tmp/cp_overwrite_src /tmp/cp_overwrite_dst && echo 'new content' > /tmp/cp_overwrite_src && echo 'old content' > /tmp/cp_overwrite_dst && cp /tmp/cp_overwrite_src /tmp/cp_overwrite_dst && cat /tmp/cp_overwrite_dst" "new content"
+test_software "文件" "mv" "rm -f /tmp/old /tmp/new && echo 'test' > /tmp/old && mv /tmp/old /tmp/new && cat /tmp/new" "test"
+test_software "文件" "rm" "touch /tmp/del && rm /tmp/del && test ! -f /tmp/del && echo ok" "ok"
+test_software "文件" "mkdir" "mkdir -p /tmp/testdir && test -d /tmp/testdir && echo ok" "ok"
+test_software "文件" "rmdir" "mkdir -p /tmp/empty && rmdir /tmp/empty && test ! -d /tmp/empty && echo ok" "ok"
+test_software "文件" "touch" "touch /tmp/touch.txt && test -f /tmp/touch.txt && echo ok" "ok"
+test_software "文件" "chmod" "touch /tmp/ch && chmod 644 /tmp/ch && ls -l /tmp/ch | grep rw-r--r--" "rw-r--r--"
+test_software "文件" "chown" "touch /tmp/chown && chown root:root /tmp/chown 2>&1; echo ok" "ok"
+test_software "文件" "ln" "rm -f /tmp/link && echo 'test' > /tmp/orig && ln -s /tmp/orig /tmp/link && cat /tmp/link" "test"
+test_software "文件" "readlink" "rm -f /tmp/link2 && ln -s /tmp/target /tmp/link2 && readlink /tmp/link2" "target"
+test_software "文件" "stat" "stat /etc/os-release" "File:"
+test_software "文件" "file" "file /bin/busybox" "" "file"
+test_software "文件" "du" "du -sh /etc" ""
+test_software "文件" "df" "df -h /" ""
+test_software "文件" "dd" "dd if=/dev/zero of=/tmp/dd.txt bs=1k count=1 2>&1" ""
+test_software "文件" "sync" "sync && echo ok" "ok"
+test_software "文件" "truncate" "truncate -s 100 /tmp/trunc && stat /tmp/trunc | grep 'Size: 100'" "100"
+test_software "文件" "split" "echo -e '1\n2\n3\n4' > /tmp/sp && rm -f /tmp/sp_* && split -l 2 /tmp/sp /tmp/sp_ && ls /tmp/sp_* | wc -l" "2"
+test_software "文件" "csplit" "echo ok" "ok"
+test_software "文件" "tar" "echo 'test' > /tmp/test.txt && tar czf /tmp/test.tar.gz -C /tmp test.txt && echo ok" "ok"
+test_software "文件" "gzip" "echo 'test' | gzip | gunzip" "test"
+test_software "文件" "bzip2" "echo 'test' | bzip2 | bunzip2" "test"
+test_software "文件" "xz" "rm -f /tmp/xz.txt /tmp/xz.txt.xz && echo 'test' > /tmp/xz.txt && xz /tmp/xz.txt && test -f /tmp/xz.txt.xz && echo ok" "ok" "xz"
+test_software "文件" "unxz" "rm -f /tmp/xz2.txt /tmp/xz2.txt.xz && echo 'test' > /tmp/xz2.txt && xz /tmp/xz2.txt && unxz /tmp/xz2.txt.xz && cat /tmp/xz2.txt" "test" "xz"
+test_software "文件" "zstd" "rm -f /tmp/zst.txt /tmp/zst.txt.zst && echo 'test' > /tmp/zst.txt && zstd -q /tmp/zst.txt -o /tmp/zst.txt.zst && test -f /tmp/zst.txt.zst && echo ok" "ok" "zstd"
+
+# ============================================================
+# 3. 文本处理工具 (20+)
+# ============================================================
+section_header "3. Text Processing (20)"
+
+test_software "文本" "diff" "echo 'a' > /tmp/da && echo 'b' > /tmp/db && diff /tmp/da /tmp/db; test \$? -eq 1 && echo diff_ok" "diff_ok"
+test_software "文本" "patch" "echo ok" "ok"
+test_software "文本" "comm" "echo -e '1\n2' > /tmp/c1 && echo -e '2\n3' > /tmp/c2 && comm /tmp/c1 /tmp/c2" ""
+test_software "文本" "join" "echo ok" "ok"
+test_software "文本" "fold" "echo 'abcdefghijklmn' | fold -w 5 | head -1" "abcde"
+test_software "文本" "fmt" "echo 'test line' | fmt" "test" "fmt"
+test_software "文本" "nl" "echo -e 'a\nb' | nl | grep '1'" "1"
+test_software "文本" "expand" "echo ok" "ok"
+test_software "文本" "unexpand" "echo ok" "ok"
+test_software "文本" "column" "echo -e 'a\tb\nc\td' | column -t" "" "column"
+test_software "文本" "rev" "echo 'abc' | rev" "cba"
+test_software "文本" "strings" "strings /bin/busybox | head -1" ""
+test_software "文本" "hexdump" "echo 'test' | hexdump -C | grep test" "test"
+test_software "文本" "od" "echo 'a' | od -c" "a"
+test_software "文本" "base64" "echo 'test' | base64" ""
+test_software "文本" "base32" "echo 'test' | base32" "" "base32"
+test_software "文本" "iconv" "echo 'test' | iconv -f UTF-8 -t UTF-8" "test"
+test_software "文本" "dos2unix" "echo -e 'test\r' | dos2unix | od -c | grep -v '\\\\r'" ""
+test_software "文本" "unix2dos" "echo ok" "ok"
+test_software "文本" "look" "echo ok" "ok"
+
+# ============================================================
+# 4. 编译工具链 (24)
+# ============================================================
+section_header "4. Build Toolchain (29)"
+
+test_software "编译" "gcc" "gcc --version" "gcc"
+test_software "编译" "g++" "g++ --version" "g++"
+test_software "编译" "cc" "cc --version" "" "cc"
+test_software "编译" "c++" "c++ --version" "" "c++"
+# printf, not echo: busybox echo does not expand \n, so cpp received a single
+# line and the macro was never on a line of its own to expand.
+test_software "编译" "cpp" "printf '#define X 1\nX\n' | cpp -P | grep 1" "1" "cpp"
+# Regression (#29): compile a file big enough that cc1 runs longer than the 1s
+# internal waitpid timeout. do_wait() used to report that timeout as a signal,
+# so the gcc driver's wait on cc1 returned EINTR and it died with
+# "fatal error: failed to get exit status: Interrupted system call". 100
+# functions is the smallest size that reproduces it reliably (~2s total here);
+# anything larger only slows the suite down.
+test_software "编译" "gcc-slow-compile" "python3 -c \"
+with open('/tmp/waitpid_regress.c','w') as f:
+    f.write('#include <stdio.h>\n#include <math.h>\n\n')
+    for i in range(100):
+        f.write('double func_%d(double x) { return sin(x)*%d.0 + cos(x*%d); }\n' % (i,i,i))
+    f.write('int main() { return 0; }\n')
+\" && gcc /tmp/waitpid_regress.c -o /tmp/waitpid_regress -lm && /tmp/waitpid_regress && echo SLOW_COMPILE_OK" "SLOW_COMPILE_OK"
+test_software "编译" "make" "make --version" "Make" "make"
+test_software "编译" "cmake" "cmake --version" "cmake"
+test_software "编译" "autoconf" "autoconf --version" "autoconf"
+test_software "编译" "automake" "automake --version" "automake"
+test_software "编译" "libtool" "libtool --version" "libtool"
+test_software "编译" "m4" "echo 'define(X,Y)X' | m4" "Y" "m4"
+test_software "编译" "ld" "ld --version" "" "ld"
+test_software "编译" "as" "as --version" "" "as"
+test_software "编译" "ar" "ar --version" "" "ar"
+test_software "编译" "ranlib" "ranlib --version" "" "ranlib"
+test_software "编译" "nm" "nm --version" "" "nm"
+test_software "编译" "objdump" "objdump --version" "" "objdump"
+test_software "编译" "objcopy" "objcopy --version" "" "objcopy"
+test_software "编译" "strip" "strip --version" "" "strip"
+test_software "编译" "size" "size --version" "" "size"
+test_software "编译" "readelf" "readelf --version" "readelf"
+test_software "编译" "pkg-config" "pkg-config --version" "" "pkg-config"
+test_software "编译" "bison" "bison --version" "bison"
+test_software "编译" "flex" "flex --version" "flex"
+test_software "编译" "clang" "clang --version" "" "clang"
+test_software "编译" "clang-compile" "echo 'int main(){return 0;}' > /tmp/clang_test.c && clang -o /tmp/clang_test /tmp/clang_test.c && /tmp/clang_test && echo CLANG_OK" "CLANG_OK" "clang"
+test_software "编译" "go" "go version" "go" "go"
+test_software "编译" "go-compile" "echo 'package main; func main(){}' > /tmp/go_test.go && go tool compile -o /tmp/go_test.o /tmp/go_test.go && echo GO_COMPILE_OK" "GO_COMPILE_OK" "go"
+
+# ============================================================
+# 5. Python 生态 (15+)
+# ============================================================
+section_header "5. Python Ecosystem (16)"
+
+test_software "Python" "python3" "python3 --version" "Python 3"
+test_software "Python" "python" "python --version 2>&1" "Python"
+test_software "Python" "pip3" "pip3 --version" "pip"
+test_software "Python" "pip" "pip --version" "pip"
+test_software "Python" "2to3" "2to3 --help" ""
+test_software "Python" "pydoc3" "pydoc3 -h 2>&1 | head -1" ""
+test_software "Python" "python-json" "python3 -c 'import json; print(\"ok\")'" "ok"
+test_software "Python" "python-sys" "python3 -c 'import sys; print(sys.version_info[0])'" "3"
+test_software "Python" "python-os" "python3 -c 'import os; print(os.name)'" "posix"
+test_software "Python" "python-re" "python3 -c 'import re; print(re.match(\"test\",\"test\").group())'" "test"
+test_software "Python" "python-math" "python3 -c 'import math; print(int(math.sqrt(4)))'" "2"
+test_software "Python" "python-datetime" "python3 -c 'import datetime; print(\"ok\")'" "ok"
+test_software "Python" "python-sqlite3" "python3 -c 'import sqlite3; print(\"ok\")'" "ok"
+test_software "Python" "python-http" "python3 -m http.server --help 2>&1 | head -1" ""
+test_software "Python" "python-venv" "python3 -m venv --help 2>&1 | head -1" "usage"
+# Regression (#22): numpy's float64<->float32 .astype() emits the ASIMD lane
+# narrow/widen instructions (FCVTN/FCVTL). Those had no gadget in the
+# guest-arm64 backend, so this died with "illegal instruction ... insn=0x0e616bff"
+# instead of printing. Both sums are 45.0 for arange(10.0).
+test_software "Python" "numpy-astype" "python3 -c \"import numpy as np; a = np.arange(10.0); b = a.astype(np.float32); c = b.astype(np.float64); print(b.sum(), c.sum())\"" "45.0 45.0"
+
+# ============================================================
+# 6. Node.js 生态 (10+)
+# ============================================================
+section_header "6. Node.js Ecosystem (12)"
+
+test_software "Node.js" "node" "timeout 5 node --version" "v"
+test_software "Node.js" "npm" "timeout 60 npm --version" ""
+test_software "Node.js" "npx" "timeout 60 npx --version" ""
+test_software "Node.js" "npm-list" "timeout 120 npm list --depth=0 2>&1; echo ok" "ok"
+test_software "Node.js" "npx-help" "timeout 60 npx --help 2>&1 | head -1" ""
+test_software "Node.js" "node-console" "timeout 5 node -e 'console.log(\"ok\")'" "ok"
+test_software "Node.js" "node-math" "timeout 5 node -e 'console.log(2+2)'" "4"
+test_software "Node.js" "node-Buffer" "timeout 5 node -e 'console.log(Buffer.from(\"test\").toString())'" "test"
+test_software "Node.js" "node-crypto" "timeout 5 node -e 'console.log(require(\"crypto\").randomBytes(4).length)'" "4"
+test_software "Node.js" "node-fs" "timeout 5 node -e 'require(\"fs\").writeFileSync(\"/tmp/n.txt\",\"ok\"); console.log(require(\"fs\").readFileSync(\"/tmp/n.txt\",\"utf8\"))'" "ok"
+test_software "Node.js" "node-path" "timeout 5 node -e 'console.log(require(\"path\").join(\"a\",\"b\"))'" "a/b"
+test_software "Node.js" "node-os" "timeout 5 node -e 'console.log(require(\"os\").platform())'" "linux"
+
+# ============================================================
+# 7. 其他编程语言 (12)
+# ============================================================
+section_header "7. Other Languages (12)"
+
+test_software "语言" "php" "php --version" "PHP" "php"
+test_software "语言" "php-eval" "php -r 'echo 2+2;'" "4" "php"
+test_software "语言" "ruby" "ruby --version" "ruby" "ruby"
+test_software "语言" "ruby-eval" "ruby -e 'puts 2+2'" "4" "ruby"
+test_software "语言" "perl" "perl --version" "perl" "perl"
+test_software "语言" "perl-eval" "perl -e 'print 2+2'" "4" "perl"
+test_software "语言" "lua" "lua5.4 -v 2>&1 || lua -v 2>&1" "Lua" "lua5.4"
+test_software "语言" "lua-eval" "lua5.4 -e 'print(2+2)' 2>/dev/null || lua -e 'print(2+2)'" "4" "lua5.4"
+test_software "语言" "sh" "sh -c 'echo ok'" "ok"
+test_software "语言" "bash" "bash -c 'echo ok'" "ok" "bash"
+test_software "语言" "ash" "ash -c 'echo ok'" "ok"
+test_software "语言" "dash" "dash -c 'echo ok' 2>&1 || echo skip" ""
+
+# ============================================================
+# 8. 网络工具 (20)
+# ============================================================
+section_header "8. Network Tools (20)"
+
+test_software "网络" "curl" "curl --version" "curl"
+test_software "网络" "wget" "wget --version" "Wget"
+test_software "网络" "ping" "ping -c 1 127.0.0.1" ""
+test_software "网络" "traceroute" "traceroute --version 2>&1 || echo ok" ""
+test_software "网络" "netstat" "netstat -h 2>&1 | head -1" ""
+test_software "网络" "ss" "ss -h 2>&1 | head -1" ""
+test_software "网络" "ip" "ip addr show lo 2>&1 || ip link 2>&1 || echo ok" ""
+test_software "网络" "ifconfig" "ifconfig lo 2>&1 || ifconfig -a 2>&1 || echo ok" ""
+test_software "网络" "route" "route -n 2>&1 || echo ok" ""
+test_software "网络" "arp" "arp -h 2>&1 | head -1" ""
+test_software "网络" "nslookup" "nslookup www.google.com 2>&1" "Address"
+test_software "网络" "dig" "dig -v 2>&1" "DiG" "dig"
+test_software "网络" "host" "host www.google.com 2>&1 || echo ok" ""
+test_software "网络" "telnet" "echo ok" "ok"
+test_software "网络" "nc" "nc -h 2>&1 | head -1" ""
+test_software "网络" "netcat" "netcat -h 2>&1 | head -1" ""
+test_software "网络" "socat" "socat -V" "socat"
+test_software "网络" "ssh" "ssh -V 2>&1" "OpenSSH"
+test_software "网络" "scp" "scp 2>&1 | head -1" ""
+test_software "网络" "sftp" "sftp 2>&1 | head -1" ""
+
+# ============================================================
+# 9. 版本控制 (8)
+# ============================================================
+section_header "9. Version Control (8)"
+
+test_software "VCS" "git" "git --version" "git"
+test_software "VCS" "git-init" "rm -rf /tmp/testrepo && git init /tmp/testrepo 2>&1 && test -d /tmp/testrepo/.git && echo ok" "ok" "git"
+test_software "VCS" "git-config" "git config --global user.name 2>&1 || echo ok" ""
+test_software "VCS" "git-log" "cd /tmp/testrepo && git log 2>&1 || echo ok" ""
+test_software "VCS" "svn" "svn --version" "svn"
+test_software "VCS" "hg" "hg --version" "Mercurial" "hg"
+test_software "VCS" "cvs" "cvs --version 2>&1 || echo ok" ""
+test_software "VCS" "rcs" "echo ok" "ok"
+
+# ============================================================
+# 10. 编辑器 (8)
+# ============================================================
+section_header "10. Editors (8)"
+
+test_software "编辑器" "vi" "echo 'itest' | vi -es '+%p' '+q' 2>&1 || echo ok" ""
+test_software "编辑器" "vim" "vim --version 2>&1 | head -1" "VIM"
+test_software "编辑器" "nano" "nano --version" "nano" "nano"
+test_software "编辑器" "ed" "printf 'a\ntest\n.\n1p\nq\n' | ed 2>&1" "test" "ed"
+test_software "编辑器" "emacs" "emacs --version 2>&1 || echo skip" ""
+test_software "编辑器" "joe" "joe -help 2>&1 || echo skip" ""
+test_software "编辑器" "sed-edit" "echo 'test' | sed 's/test/ok/'" "ok"
+test_software "编辑器" "awk-edit" "echo 'a b' | awk '{print \$1}'" "a"
+
+# ============================================================
+# 11. Shell 工具 (8)
+# ============================================================
+section_header "11. Shell Tools (8)"
+
+test_software "Shell" "bash" "bash --version" "bash" "bash"
+test_software "Shell" "zsh" "zsh --version" "zsh"
+test_software "Shell" "fish" "fish --version" "fish"
+test_software "Shell" "dash" "dash -c 'echo ok' 2>&1 || echo skip" ""
+test_software "Shell" "screen" "screen -v" "Screen"
+test_software "Shell" "tmux" "tmux -V" "tmux"
+test_software "Shell" "script" "echo ok" "ok"
+test_software "Shell" "expect" "expect -v" "expect"
+
+# ============================================================
+# 12. 数据库 (8)
+# ============================================================
+section_header "12. Databases (8)"
+
+test_software "数据库" "sqlite3" "sqlite3 --version" "" "sqlite3"
+test_software "数据库" "sqlite3-create" "sqlite3 :memory: 'CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT * FROM t;'" "1" "sqlite3"
+test_software "数据库" "redis-cli" "redis-cli --version" "redis-cli"
+test_software "数据库" "psql" "psql --version" "psql"
+test_software "数据库" "mysql" "mysql --version 2>&1 || echo skip" ""
+test_software "数据库" "mariadb" "mariadb --version 2>&1 || echo ok" ""
+test_software "数据库" "mongosh" "mongosh --version 2>&1 || echo skip" ""
+test_software "数据库" "redis-server" "redis-server --version" "Redis"
+
+# ============================================================
+# 13. 多媒体工具 (12)
+# ============================================================
+section_header "13. Multimedia Tools (12)"
+
+test_software "多媒体" "ffmpeg" "timeout 5 ffmpeg -version 2>&1 | head -1" "ffmpeg"
+test_software "多媒体" "ffprobe" "timeout 5 ffprobe -version 2>&1 | head -1" "ffprobe"
+test_software "多媒体" "ffplay" "timeout 5 ffplay -version 2>&1 | head -1 || echo skip" ""
+test_software "多媒体" "convert" "convert -version 2>&1 | head -1" "" "convert"
+test_software "多媒体" "identify" "identify -version 2>&1 | head -1" "" "identify"
+test_software "多媒体" "mogrify" "mogrify -version 2>&1 | head -1" "" "mogrify"
+test_software "多媒体" "gm" "gm version 2>&1 | head -1" "" "gm"
+test_software "多媒体" "gm-convert" "gm convert 2>&1 | head -1 || echo ok" "" "gm"
+test_software "多媒体" "sox" "sox --version" "SoX"
+test_software "多媒体" "play" "play --version 2>&1 || echo ok" ""
+test_software "多媒体" "pdftk" "pdftk --version 2>&1 || echo skip" ""
+test_software "多媒体" "pdfinfo" "pdfinfo -v 2>&1 || echo skip" ""
+
+# ============================================================
+# 14. 加密和安全 (11)
+# ============================================================
+section_header "14. Crypto & Security (11)"
+
+test_software "安全" "openssl" "openssl version" "OpenSSL"
+test_software "安全" "openssl-enc" "echo 'test' | openssl enc -aes-256-cbc -pbkdf2 -pass pass:123 2>/dev/null | openssl enc -d -aes-256-cbc -pbkdf2 -pass pass:123 2>/dev/null" "test" "openssl"
+test_software "安全" "gpg" "gpg --version" "GnuPG" "gpg"
+test_software "安全" "gpg-agent" "gpg-agent --version" "gpg-agent"
+test_software "安全" "sha256sum" "echo 'test' | sha256sum" ""
+test_software "安全" "sha512sum" "echo 'test' | sha512sum" ""
+test_software "安全" "sha1sum" "echo 'test' | sha1sum" ""
+test_software "安全" "md5sum" "echo 'test' | md5sum" ""
+test_software "安全" "age" "age --version" "age"
+test_software "安全" "ssh-keygen" "ssh-keygen -h 2>&1 | head -1" ""
+test_software "安全" "ssh-keygen-rsa" "rm -f /tmp/test_rsa_key /tmp/test_rsa_key.pub && ssh-keygen -t rsa -b 2048 -f /tmp/test_rsa_key -N '' -q && test -f /tmp/test_rsa_key.pub && echo KEYGEN_OK" "KEYGEN_OK"
+
+# ============================================================
+# 15. 系统监控 (11)
+# ============================================================
+section_header "15. System Monitoring (11)"
+
+test_software "监控" "top" "echo ok" "ok"
+test_software "监控" "htop" "htop --version" "htop"
+test_software "监控" "ps" "ps aux | head -1" ""
+test_software "监控" "pstree" "pstree -h 2>&1 | head -1 || echo ok" ""
+test_software "监控" "vmstat" "vmstat -h 2>&1 | head -1 || echo ok" ""
+test_software "监控" "iostat" "iostat -h 2>&1 | head -1 || echo ok" ""
+test_software "监控" "free" "free -h" ""
+test_software "监控" "uptime" "uptime" ""
+test_software "监控" "w" "w -h 2>&1 | head -1 || echo ok" ""
+test_software "监控" "who" "who am i 2>&1 || echo ok" ""
+test_software "监控" "last" "last -1 2>&1 || echo ok" ""
+
+# ============================================================
+# 16. 开发调试工具 (12)
+# ============================================================
+section_header "16. Dev & Debug Tools (12)"
+
+test_software "调试" "gdb" "gdb --version 2>&1 | head -1" "" "gdb"
+test_software "调试" "strace" "strace -V" "strace"
+test_software "调试" "ltrace" "ltrace -V 2>&1 || echo skip" ""
+test_software "调试" "ldd" "ldd --version 2>&1 || ldd /bin/busybox 2>&1 | head -1" ""
+test_software "调试" "objdump" "objdump --version" "" "objdump"
+test_software "调试" "nm" "nm --version" "" "nm"
+test_software "调试" "readelf" "readelf --version" "readelf"
+test_software "调试" "lsof" "lsof -v 2>&1 || echo ok" ""
+test_software "调试" "time" "time echo ok 2>&1" "ok"
+test_software "调试" "timeout" "timeout 1 echo ok" "ok"
+test_software "调试" "valgrind" "valgrind --version 2>&1 || echo skip" ""
+test_software "调试" "perf" "perf --version 2>&1 || echo skip" ""
+
+# ============================================================
+# 17. 包管理和安装 (6)
+# ============================================================
+section_header "17. Package Managers (6)"
+
+test_software "包管理" "apk" "apk --version" "apk-tools"
+test_software "包管理" "apt" "apt --version 2>&1 || echo skip" ""
+test_software "包管理" "yum" "yum --version 2>&1 || echo skip" ""
+test_software "包管理" "rpm" "rpm --version 2>&1 || echo skip" ""
+test_software "包管理" "dpkg" "dpkg --version 2>&1 || echo skip" ""
+test_software "包管理" "pip3" "pip3 --version" "pip"
+
+# ============================================================
+# 18. 数据处理工具 (8)
+# ============================================================
+section_header "18. Data Processing (8)"
+
+test_software "数据" "jq" "echo '{\"a\":1}' | jq .a" "1" "jq"
+test_software "数据" "bc" "echo '2+2' | bc" "4"
+test_software "数据" "dc" "echo '2 2 + p' | dc" "4"
+test_software "数据" "units" "units --version 2>&1 || echo skip" ""
+test_software "数据" "factor" "factor 12" ""
+test_software "数据" "numfmt" "echo 1000000 | numfmt --to=iec" "" "numfmt"
+test_software "数据" "shuf" "seq 5 | shuf | wc -l" "5"
+test_software "数据" "rsync" "rsync --version" "rsync"
+
+# ============================================================
+# 19. Modern CLI Tools (8)
+# ============================================================
+section_header "19. Modern CLI Tools (8)"
+
+test_software "CLI" "gh" "timeout 30 gh --version" "gh"
+test_software "CLI" "gh-help" "timeout 30 gh help 2>&1 | head -1" ""
+test_software "CLI" "uv" "timeout 30 uv --version" "uv"
+test_software "CLI" "uv-init" "cd /tmp && rm -rf uvtest123 && mkdir uvtest123 && cd uvtest123 && timeout 60 uv init 2>&1 && test -f pyproject.toml && echo UV_INIT_OK" "UV_INIT_OK"
+test_software "CLI" "uv-pip-list" "timeout 30 uv pip list 2>&1 || echo ok" ""
+test_software "CLI" "uv-python" "timeout 30 uv python list 2>&1 | head -1" ""
+test_software "CLI" "yt-dlp" "timeout 10 yt-dlp --version" ""
+test_software "CLI" "hg" "timeout 10 hg --version" "Mercurial"
+
+# ============================================================
+# Summary
+# ============================================================
+echo "" | tee -a "$REPORT"
+echo "---" | tee -a "$REPORT"
+echo "" | tee -a "$REPORT"
+echo "## Summary" | tee -a "$REPORT"
+echo "" | tee -a "$REPORT"
+
+RATE=$(echo "scale=2; $PASS * 100 / $TOTAL" | bc)
+echo "| Metric | Value |" | tee -a "$REPORT"
+echo "|--------|-------|" | tee -a "$REPORT"
+echo "| Total  | $TOTAL |" | tee -a "$REPORT"
+echo "| PASS   | $PASS |" | tee -a "$REPORT"
+echo "| FAIL   | $FAIL |" | tee -a "$REPORT"
+echo "| Rate   | ${RATE}% |" | tee -a "$REPORT"
+echo "" | tee -a "$REPORT"
+
+echo ""
+echo "========================================"
+echo "Test complete!"
+echo "========================================"
+echo "Total: $TOTAL"
+echo "PASS:  $PASS"
+echo "FAIL:  $FAIL"
+echo "Rate:  ${RATE}%"
+echo ""
+echo "Report: $REPORT"
+echo "========================================"

--- a/fs/fake.c
+++ b/fs/fake.c
@@ -403,6 +403,7 @@ static struct fd *fakefs_open(struct mount *mount, const char *path, int flags, 
         if (flags & O_TRUNC_) real_flags |= O_TRUNC;
         if (flags & O_APPEND_) real_flags |= O_APPEND;
         if (flags & O_NONBLOCK_) real_flags |= O_NONBLOCK;
+        if (flags & O_NOFOLLOW_) real_flags |= O_NOFOLLOW;
         int fd_no = open(host_abs, real_flags, 0666);
         if (fd_no < 0) {
             return ERR_PTR(errno_map());

--- a/fs/fake.c
+++ b/fs/fake.c
@@ -721,7 +721,13 @@ static int fakefs_stat(struct mount *mount, const char *path, struct statbuf *fa
             return errno_map();
         }
         memset(fake_stat, 0, sizeof(*fake_stat));
+        /* Must match what fakefs_fstat gets via realfs.fstat/copy_stat, or
+         * coreutils' psame_inode(stat, fstat) sees dev mismatch and reports
+         * "file was replaced while being copied". */
+        fake_stat->dev = dev_fake_from_real(host_stat.st_dev);
         fake_stat->inode = (ino_t)host_stat.st_ino;
+        fake_stat->nlink = host_stat.st_nlink;
+        fake_stat->blksize = host_stat.st_blksize;
         /* Pick a sensible mode: keep host's S_IFMT, default to 0644/0755. */
         mode_t_ type = host_stat.st_mode & S_IFMT;
         fake_stat->mode = type | (S_ISDIR(host_stat.st_mode) ? 0755 : 0644);

--- a/fs/generic.c
+++ b/fs/generic.c
@@ -37,7 +37,12 @@ struct fd *generic_openat(struct fd *at, const char *path_raw, int flags, int mo
 
     // TODO really, really, seriously reconsider what I'm doing with the strings
     char path[MAX_PATH];
-    int err = path_normalize(at, path_raw, path, N_SYMLINK_FOLLOW |
+    // O_NOFOLLOW has to be honored here rather than by handing the flag to the
+    // host open(): path_normalize resolves the final component itself, so by
+    // the time the fs open() runs the symlink is already gone. Leaving it
+    // unresolved makes the S_ISLNK check below return ELOOP, as Linux does.
+    int err = path_normalize(at, path_raw, path,
+            (flags & O_NOFOLLOW_ ? N_SYMLINK_NOFOLLOW : N_SYMLINK_FOLLOW) |
             (flags & O_CREAT_ ? N_PARENT_DIR_WRITE : 0));
     if (err < 0)
         return ERR_PTR(err);

--- a/fs/real.c
+++ b/fs/real.c
@@ -48,6 +48,12 @@ static int open_flags_real_from_fake(int flags) {
     if (flags & O_TRUNC_) real_flags |= O_TRUNC;
     if (flags & O_APPEND_) real_flags |= O_APPEND;
     if (flags & O_NONBLOCK_) real_flags |= O_NONBLOCK;
+    if (flags & O_NOFOLLOW_) real_flags |= O_NOFOLLOW;
+    /* O_DIRECTORY is deliberately not forwarded: generic_openat() already
+     * enforces ENOTDIR against the guest's view of the type, and Darwin's
+     * open() has no O_DIRECTORY. O_PATH/O_DIRECT have no Darwin equivalent
+     * either (F_NOCACHE is the closest to O_DIRECT and is advisory), so they
+     * stay guest-side only. */
     return real_flags;
 }
 
@@ -61,6 +67,7 @@ static int open_flags_fake_from_real(int flags) {
     if (flags & O_TRUNC) fake_flags |= O_TRUNC_;
     if (flags & O_APPEND) fake_flags |= O_APPEND_;
     if (flags & O_NONBLOCK) fake_flags |= O_NONBLOCK_;
+    if (flags & O_NOFOLLOW) fake_flags |= O_NOFOLLOW_;
     return fake_flags;
 }
 

--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -614,10 +614,16 @@ retry:
     current->blocking = true;
     {
         struct timespec waitpid_timeout = {.tv_sec = 1, .tv_nsec = 0};
-        if (wait_for(&current->group->child_exit, &pids_lock, &waitpid_timeout)) {
-            // Signal received during wait
+        // wait_for returns _EINTR (signal), _ETIMEDOUT (deadline expired), or
+        // 0 (child_exit was signalled). Only a real signal may set got_signal:
+        // treating _ETIMEDOUT as one made every wait for a child that ran
+        // longer than the timeout fail with EINTR, which broke gcc (cc1 easily
+        // exceeds 1s under emulation) and every other fork+wait caller.
+        // On _ETIMEDOUT and 0 alike we just fall through to retry, which
+        // rescans for a zombie and reaps it if the child has since exited.
+        int wait_err = wait_for(&current->group->child_exit, &pids_lock, &waitpid_timeout);
+        if (wait_err == _EINTR)
             got_signal = true;
-        }
     }
     current->blocking = false;
     {

--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -576,6 +576,9 @@ retry:
                     continue;
                 no_children = false;
                 info->child.pid = task->pid;
+                // Must be read before reap_if_needed: reaping runs
+                // task_destroy, which memsets the task struct.
+                info->child.uid = task->uid;
                 if (reap_if_needed(task, info, rusage, options))
                     goto found_something;
             }
@@ -592,13 +595,16 @@ retry:
             goto error;
         task = task->group->leader;
         info->child.pid = id;
+        info->child.uid = task->uid;
         if (reap_if_needed(task, info, rusage, options))
             goto found_something;
     }
 
     // WNOHANG leaves the info in an implementation-defined state. set the pid
-    // to 0 so wait4 can pass that along correctly.
+    // to 0 so wait4 can pass that along correctly. Clear uid alongside it so a
+    // "no child ready" result doesn't report the uid of a candidate we scanned.
     info->child.pid = 0;
+    info->child.uid = 0;
     if (options & WNOHANG_) {
         info->sig = SIGCHLD_;
         goto found_something;

--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -643,12 +643,50 @@ error:
     return err;
 }
 
+// Convert the raw wait(2) status word that do_wait produces into the
+// (si_code, si_status) pair waitid(2) is specified to return. The encodings
+// come from the places that write child.status:
+//   sys_exit/sys_exit_group  do_exit(status << 8)   -> low byte 0
+//   deliver SIGNAL_KILL      do_exit_group(sig)     -> low byte is the signal
+//   deliver SIGNAL_STOP      sig << 8 | 0x7f
+//   ptrace stop              signal << 8 | 0x7f
+// Nothing in iSH sets the 0x80 core-dump bit today, so CLD_DUMPED is
+// unreachable in practice; it is handled anyway so this stays correct if
+// core dumps are ever implemented.
+static void waitid_decode_status(struct siginfo_ *info) {
+    dword_t status = info->child.status;
+    info->sig = SIGCHLD_;
+    if ((status & 0xff) == 0x7f) {
+        // stopped: WIFSTOPPED, signal in the high byte
+        info->code = CLD_STOPPED_;
+        info->child.status = (status >> 8) & 0xff;
+    } else if (status == 0xffff) {
+        // continued: WIFCONTINUED. Nothing produces this yet (SIGCONT does not
+        // set group_exit_code), but decode it so the case is not silently
+        // misreported as an exit if WCONTINUED support lands.
+        info->code = CLD_CONTINUED_;
+        info->child.status = SIGCONT_;
+    } else if ((status & 0x7f) != 0) {
+        // terminated by a signal: WIFSIGNALED, signal in the low 7 bits
+        info->code = (status & 0x80) ? CLD_DUMPED_ : CLD_KILLED_;
+        info->child.status = status & 0x7f;
+    } else {
+        // normal exit: WIFEXITED, exit code in the high byte
+        info->code = CLD_EXITED_;
+        info->child.status = (status >> 8) & 0xff;
+    }
+}
+
 dword_t sys_waitid(int_t idtype, pid_t_ id, addr_t info_addr, int_t options) {
     STRACE("waitid(%d, %d, %#x, %#x)", idtype, id, info_addr, options);
     struct siginfo_ info = {};
     int_t res = do_wait(idtype, id, &info, NULL, options);
     if (res < 0 || (res == 0 && info.child.pid == 0))
         return res;
+    // do_wait hands back the raw wait(2)-encoded status, which is what wait4
+    // wants but not what waitid does: waitid must report the decoded value in
+    // si_status and say which kind of event it was in si_code.
+    waitid_decode_status(&info);
     if (info_addr != 0 && user_put(info_addr, info))
         return _EFAULT;
     return 0;

--- a/kernel/fs.h
+++ b/kernel/fs.h
@@ -111,8 +111,18 @@ bool mount_param_flag(const char *info, const char *flag);
 #define O_TRUNC_ (1 << 9)
 #define O_APPEND_ (1 << 10)
 #define O_NONBLOCK_ (1 << 11)
-#define O_DIRECTORY_ (1 << 16)
+/* arm64 overrides the asm-generic values for the three flags below
+ * (arch/arm64/include/uapi/asm/fcntl.h, for AArch32 compat). O_DIRECTORY_ used
+ * to carry the x86 value 1<<16, which no aarch64 guest ever sets — so the
+ * generic_openat() ENOTDIR check never fired — while 1<<16 is arm64's O_DIRECT,
+ * making O_DIRECT opens look like O_DIRECTORY ones. */
+#define O_DIRECTORY_ (1 << 14)
+#define O_NOFOLLOW_ (1 << 15)
+#define O_DIRECT_ (1 << 16)
+#define O_LARGEFILE_ (1 << 17)
+#define O_NOATIME_ (1 << 18)
 #define O_CLOEXEC_ (1 << 19)
+#define O_PATH_ (1 << 21)
 
 // generic ioctls
 #define FIONREAD_ 0x541b

--- a/kernel/signal.h
+++ b/kernel/signal.h
@@ -64,6 +64,13 @@ struct sigaction_ {
 #define SI_TIMER_ -2
 #define SI_TKILL_ -6
 #define SI_KERNEL_ 128
+// si_code values for SIGCHLD (see waitid(2))
+#define CLD_EXITED_ 1
+#define CLD_KILLED_ 2
+#define CLD_DUMPED_ 3
+#define CLD_TRAPPED_ 4
+#define CLD_STOPPED_ 5
+#define CLD_CONTINUED_ 6
 #define TRAP_TRACE_ 2
 #define SEGV_MAPERR_ 1
 #define SEGV_ACCERR_ 2

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -54,8 +54,18 @@ struct task *task_create_(struct task *parent) {
     list_init(&pid->pgroup);
 
     struct task *task = malloc(sizeof(struct task));
-    if (task == NULL)
+    if (task == NULL) {
+        // Release pids_lock before bailing out. Returning while still holding
+        // it wedged the whole kernel: every later task_create_, pid_get_task
+        // and signal delivery blocks on this lock forever, so an allocation
+        // failure turned into a total freeze instead of one failed fork.
+        // Also roll back the pid slot claimed above, which would otherwise be
+        // permanently reserved for a task that was never created.
+        pid->id = 0;
+        pid->task = NULL;
+        unlock(&pids_lock);
         return NULL;
+    }
     *task = (struct task) {};
     if (parent != NULL)
         *task = *parent;

--- a/tests/regress/README.md
+++ b/tests/regress/README.md
@@ -1,0 +1,55 @@
+# fs/wait syscall regression tests
+
+These pin the observable behaviour of five fixes so a future change that
+reintroduces one of them fails here instead of in a user's shell.
+
+| Fix | What broke before it | Covered by |
+| --- | --- | --- |
+| #30 `O_DIRECTORY` flag value | `O_DIRECTORY_` carried the x86 value `1<<16` instead of aarch64's `0x4000`, so the `ENOTDIR` check never fired and `O_DIRECT` (`1<<16` on arm64) was misread as `O_DIRECTORY`. GNU `cp` over an existing file failed with `cannot create regular file '<dst>/<src>': Not a directory`. | `regress_syscall.c`, `regress_cp.sh` |
+| #30 `O_NOFOLLOW` | Translated to the host `open()`, but `generic_openat()` resolves the last path component first, so the flag was a no-op and `open(symlink, O_NOFOLLOW)` returned an fd to the target. | `regress_syscall.c` |
+| #31 fakefs `stat`/`fstat` | The hook-routed branch of `fakefs_stat()` never set `dev` (nor `nlink`/`blksize`), so `stat()` and `fstat()` disagreed on `st_dev` for one file. GNU `cp` reads that as `skipping file '...', as it was replaced while being copied`. | `regress_syscall.c`, `regress_cp.sh` |
+| #29 `waitpid` EINTR | `do_wait()` treated its internal 1s timeout (`_ETIMEDOUT`) as a signal, so any child running longer than a second made its parent's wait fail with `EINTR`. gcc died with `failed to get exit status: Interrupted system call`. | `regress_syscall.c` |
+| `waitid` siginfo | `sys_waitid` returned the raw wait status instead of decoding it: `si_status` was `7936` for `exit(31)` and `si_code` was always 0, so a killed child looked like an exited one. `si_uid` was never set at all. | `regress_syscall.c` |
+
+## Running
+
+```sh
+tests/regress/run.sh                          # against alpine-arm64-321 via -r
+tests/regress/run.sh -i build/ish -r myrootfs # pick binary / rootfs
+tests/regress/run.sh -m -f -r alpine-arm64-fakefs   # fakefs: runs the cp cases
+```
+
+`run.sh` cross-compiles `regress_syscall.c` for the guest with
+`aarch64-linux-musl-gcc` (override with `$CC_GUEST`). If no cross-compiler is
+installed it skips rather than fails, since the toolchain is not vendored here.
+
+Every assertion in `regress_syscall.c` is mount-independent, so `-r` mode is the
+one that matters for the syscall cases. `-f` mode exists for the `cp` cases,
+which need GNU coreutils — usually only present in the fakefs rootfs. Staging a
+static binary into a fakefs means registering it in `meta.db`, which is slow, so
+`-f` skips the syscall binary and runs only `regress_cp.sh`.
+
+`regress_cp.sh` needs GNU coreutils `cp`, not busybox `cp`: only GNU `cp` probes
+its destination with `open(dst, O_PATH|O_DIRECTORY)` and compares
+`(st_dev, st_ino)` across `stat`/`fstat`. Without it the `cp` cases skip.
+
+To exercise #31 against a real fakefs mount point, pass the guest path of a file
+under one:
+
+```sh
+tests/regress/run.sh -m -f -r alpine-arm64-fakefs -f /var/minis/shared/doc.txt
+```
+
+That requires a path-translate hook, which only the iOS app installs, so it is
+optional — the `stat`/`fstat` assertions still run against the rootfs without it.
+
+## Verifying the tests actually catch the bugs
+
+Run the built binary against an iSH built from a commit before these fixes; it
+should report 16 failures across all five areas:
+
+```sh
+aarch64-linux-musl-gcc -static -O0 -o <rootfs>/tmp/regress_syscall \
+    tests/regress/regress_syscall.c
+<old-ish> -r <rootfs> /tmp/regress_syscall
+```

--- a/tests/regress/regress_asimd_fcvt.S
+++ b/tests/regress/regress_asimd_fcvt.S
@@ -1,0 +1,72 @@
+#ifdef __APPLE__
+#define NAME(x) _##x
+#else
+#define NAME(x) x
+#endif
+.text
+// Each helper is a standalone function so the compiler cannot interleave code
+// between the load, the instruction under test and the store.
+.global NAME(do_fcvtn)
+.align 4
+NAME(do_fcvtn):            // 2xdouble -> 2xfloat, low half; x0=in x1=out
+    ldr q0, [x0]
+    movi v1.4s, #0
+    fcvtn v1.2s, v0.2d
+    str q1, [x1]
+    ret
+.global NAME(do_fcvtn2)
+.align 4
+NAME(do_fcvtn2):           // narrow into high half; x2 seeds the low half
+    ldr q0, [x0]
+    ldr q1, [x2]
+    fcvtn2 v1.4s, v0.2d
+    str q1, [x1]
+    ret
+.global NAME(do_fcvtl)
+.align 4
+NAME(do_fcvtl):            // 2xfloat -> 2xdouble
+    ldr q0, [x0]
+    movi v1.4s, #0
+    fcvtl v1.2d, v0.2s
+    str q1, [x1]
+    ret
+.global NAME(do_fcvtl2)
+.align 4
+NAME(do_fcvtl2):           // widen the HIGH two floats
+    ldr q0, [x0]
+    movi v1.4s, #0
+    fcvtl2 v1.2d, v0.4s
+    str q1, [x1]
+    ret
+.global NAME(do_fcvtxn)
+.align 4
+NAME(do_fcvtxn):           // narrow with round-to-odd
+    ldr q0, [x0]
+    movi v1.4s, #0
+    fcvtxn v1.2s, v0.2d
+    str q1, [x1]
+    ret
+.global NAME(do_fcvtxn2)
+.align 4
+NAME(do_fcvtxn2):
+    ldr q0, [x0]
+    ldr q1, [x2]
+    fcvtxn2 v1.4s, v0.2d
+    str q1, [x1]
+    ret
+.global NAME(do_fcvtn_h)
+.align 4
+NAME(do_fcvtn_h):          // 4xsingle -> 4xhalf (sz=0 form)
+    ldr q0, [x0]
+    movi v1.4s, #0
+    fcvtn v1.4h, v0.4s
+    str q1, [x1]
+    ret
+.global NAME(do_fcvtl_h)
+.align 4
+NAME(do_fcvtl_h):          // 4xhalf -> 4xsingle (sz=0 form)
+    ldr q0, [x0]
+    movi v1.4s, #0
+    fcvtl v1.4s, v0.4h
+    str q1, [x1]
+    ret

--- a/tests/regress/regress_asimd_fcvt.c
+++ b/tests/regress/regress_asimd_fcvt.c
@@ -1,0 +1,82 @@
+// Regression test for #22: the ASIMD vector FP lane narrow/widen instructions
+// FCVTN/FCVTN2, FCVTL/FCVTL2 and FCVTXN/FCVTXN2 had no gadget in the
+// guest-arm64 Asbestos backend, so any guest executing one was killed outright
+// (numpy's float64<->float32 .astype() hits them). These are mandatory
+// ARMv8.0-A Advanced SIMD instructions and iSH advertises `asimd`.
+//
+// Every expected value here was taken from running the same helpers natively
+// on an Apple Silicon host, so this checks the emulated result bit-for-bit
+// against real hardware rather than against a re-derivation of the spec.
+//
+// Build:  aarch64-linux-musl-gcc -static -O0 -o regress_asimd_fcvt
+//             regress_asimd_fcvt.c regress_asimd_fcvt.S
+// Run:    ish -r <rootfs> /tmp/regress_asimd_fcvt
+// Exit status is 0 when every case passes.
+//
+// The instructions live in a separate .S file on purpose: with inline asm the
+// compiler is free to insert code between the load, the instruction under test
+// and the store, which silently invalidates the result.
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+void do_fcvtn(const void*,void*); void do_fcvtn2(const void*,void*,const void*);
+void do_fcvtl(const void*,void*); void do_fcvtl2(const void*,void*);
+void do_fcvtxn(const void*,void*); void do_fcvtxn2(const void*,void*,const void*);
+void do_fcvtn_h(const void*,void*); void do_fcvtl_h(const void*,void*);
+static int pass,fail;
+static void eq(const char*n,uint64_t*got,uint64_t e0,uint64_t e1){
+  if(got[0]==e0&&got[1]==e1){pass++;printf("  PASS  %-8s %016llx %016llx\n",n,
+     (unsigned long long)got[0],(unsigned long long)got[1]);}
+  else{fail++;printf("  FAIL  %-8s got %016llx %016llx want %016llx %016llx\n",n,
+     (unsigned long long)got[0],(unsigned long long)got[1],
+     (unsigned long long)e0,(unsigned long long)e1);}
+}
+#define A __attribute__((aligned(16)))
+int main(void){
+  A uint64_t d2[2]={0x3FF8000000000000ULL,0xC002000000000000ULL};   // 1.5, -2.25
+  A uint64_t s2[2]={((uint64_t)0xC0980000u<<32)|0x40600000u,0};      // 3.5f, -4.75f
+  A uint64_t s4[2]={((uint64_t)0xC0980000u<<32)|0x40600000u,
+                    ((uint64_t)0x41100000u<<32)|0x41000000u};        // +8.0f,9.0f high
+  A uint64_t seed[2]={((uint64_t)0x41000000u<<32)|0x41100000u,0};    // 9.0f,8.0f
+  A uint64_t o[2];
+  printf("=== FCVTN / FCVTN2 / FCVTL / FCVTL2 / FCVTXN / FCVTXN2 ===\n");
+  o[0]=o[1]=0; do_fcvtn(d2,o);
+    eq("FCVTN",o, ((uint64_t)0xC0100000u<<32)|0x3FC00000u, 0);
+  o[0]=o[1]=0; do_fcvtn2(d2,o,seed);
+    eq("FCVTN2",o, seed[0], ((uint64_t)0xC0100000u<<32)|0x3FC00000u);
+  o[0]=o[1]=0; do_fcvtl(s2,o);
+    eq("FCVTL",o, 0x400C000000000000ULL, 0xC013000000000000ULL);   // 3.5, -4.75
+  o[0]=o[1]=0; do_fcvtl2(s4,o);
+    eq("FCVTL2",o, 0x4020000000000000ULL, 0x4022000000000000ULL);  // 8.0, 9.0
+  o[0]=o[1]=0; do_fcvtxn(d2,o);
+    eq("FCVTXN",o, ((uint64_t)0xC0100000u<<32)|0x3FC00000u, 0);
+  o[0]=o[1]=0; do_fcvtxn2(d2,o,seed);
+    eq("FCVTXN2",o, seed[0], ((uint64_t)0xC0100000u<<32)|0x3FC00000u);
+
+  printf("=== sz=0 forms (single<->half) ===\n");
+  A uint64_t f4[2]={((uint64_t)0xC0980000u<<32)|0x40600000u,
+                    ((uint64_t)0x41100000u<<32)|0x41000000u};
+  o[0]=o[1]=0; do_fcvtn_h(f4,o);
+    // 3.5->0x4300, -4.75->0xC4C0, 8.0->0x4800, 9.0->0x4880
+    eq("FCVTN.4h",o, ((uint64_t)0x4880ULL<<48)|((uint64_t)0x4800ULL<<32)|((uint64_t)0xC4C0ULL<<16)|0x4300ULL, 0);
+  A uint64_t h4[2]={((uint64_t)0x4880ULL<<48)|((uint64_t)0x4800ULL<<32)|((uint64_t)0xC4C0ULL<<16)|0x4300ULL,0};
+  o[0]=o[1]=0; do_fcvtl_h(h4,o);
+    eq("FCVTL.4s",o, ((uint64_t)0xC0980000u<<32)|0x40600000u, ((uint64_t)0x41100000u<<32)|0x41000000u);
+
+  printf("=== FCVTXN round-to-odd semantics ===\n");
+  // A double just above 1.0 that is NOT representable in single: round-to-odd
+  // must give the odd-mantissa neighbour 0x3F800001, whereas FCVTN (round to
+  // nearest even) gives exactly 1.0 (0x3F800000).
+  A uint64_t tiny[2]={0x3FF0000000000001ULL,0x3FF0000000000001ULL};
+  o[0]=o[1]=0; do_fcvtxn(tiny,o);
+  uint32_t lo=(uint32_t)(o[0]&0xffffffffu);
+  if(lo==0x3F800001u){pass++;printf("  PASS  FCVTXN round-to-odd -> 0x%08x (odd mantissa)\n",lo);}
+  else{fail++;printf("  FAIL  FCVTXN round-to-odd got 0x%08x want 0x3F800001\n",lo);}
+  o[0]=o[1]=0; do_fcvtn(tiny,o);
+  lo=(uint32_t)(o[0]&0xffffffffu);
+  if(lo==0x3F800000u){pass++;printf("  PASS  FCVTN  nearest-even -> 0x%08x (contrast)\n",lo);}
+  else{fail++;printf("  FAIL  FCVTN nearest-even got 0x%08x want 0x3F800000\n",lo);}
+
+  printf("\n  PASS=%d FAIL=%d\n",pass,fail);
+  return fail?1:0;}

--- a/tests/regress/regress_cp.sh
+++ b/tests/regress/regress_cp.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Guest-side regression tests for the cp failures behind #30 and #31.
+#
+# These run inside iSH and need GNU coreutils cp, not busybox cp: only GNU cp
+# probes its destination with open(dst, O_PATH|O_DIRECTORY) and compares
+# (st_dev, st_ino) across stat/fstat, which is what both bugs broke. If GNU
+# coreutils is not installed the cp cases are skipped rather than failed.
+#
+# Usage (inside the guest):
+#   sh regress_cp.sh [fakefs_path]
+# where fakefs_path is an optional file under a fakefs mount point
+# (e.g. /var/minis/shared/doc.txt) to exercise the #31 copy-out case.
+
+pass=0
+fail=0
+skip=0
+
+ok() { pass=$((pass + 1)); echo "  PASS  $1"; }
+no() { fail=$((fail + 1)); echo "  FAIL  $1"; }
+sk() { skip=$((skip + 1)); echo "  SKIP  $1"; }
+
+# Locate a GNU cp. Alpine ships it as the coreutils multi-call binary.
+CP=""
+if command -v /usr/bin/coreutils >/dev/null 2>&1; then
+    CP="/usr/bin/coreutils --coreutils-prog=cp"
+elif command -v coreutils >/dev/null 2>&1; then
+    CP="coreutils --coreutils-prog=cp"
+elif cp --version 2>/dev/null | grep -q GNU; then
+    CP="cp"
+fi
+
+echo "=== #30 GNU cp over an existing regular file ==="
+if [ -z "$CP" ]; then
+    sk "GNU coreutils cp not installed (busybox cp does not reproduce this)"
+else
+    rm -f /tmp/regress_src.txt /tmp/regress_dst.txt
+    echo hello > /tmp/regress_src.txt
+    echo old > /tmp/regress_dst.txt
+    out=$($CP -v /tmp/regress_src.txt /tmp/regress_dst.txt 2>&1)
+    rc=$?
+    echo "  cp: $out"
+    [ "$rc" = "0" ] && ok "cp over an existing file exits 0" \
+                    || no "cp over an existing file exits 0 (rc=$rc)"
+    # The signature failure was cp rewriting the target as dst/src.
+    case "$out" in
+        *"Not a directory"*) no "no 'Not a directory' error" ;;
+        *) ok "no 'Not a directory' error" ;;
+    esac
+    got=$(cat /tmp/regress_dst.txt)
+    [ "$got" = "hello" ] && ok "destination content overwritten" \
+                         || no "destination content overwritten (got '$got')"
+    rm -f /tmp/regress_src.txt /tmp/regress_dst.txt
+fi
+
+echo ""
+echo "=== #30 cp -r still works (guard against breaking real directories) ==="
+if [ -z "$CP" ]; then
+    sk "GNU coreutils cp not installed"
+else
+    rm -rf /tmp/regress_rsrc /tmp/regress_rdst
+    mkdir -p /tmp/regress_rsrc/sub
+    echo nested > /tmp/regress_rsrc/sub/b.txt
+    $CP -r /tmp/regress_rsrc /tmp/regress_rdst 2>&1
+    [ "$?" = "0" ] && ok "cp -r exits 0" || no "cp -r exits 0"
+    got=$(cat /tmp/regress_rdst/sub/b.txt 2>/dev/null)
+    [ "$got" = "nested" ] && ok "cp -r copied nested content" \
+                          || no "cp -r copied nested content (got '$got')"
+    rm -rf /tmp/regress_rsrc /tmp/regress_rdst
+fi
+
+echo ""
+echo "=== #31 cp out of a fakefs mount point ==="
+SRC="$1"
+if [ -z "$CP" ]; then
+    sk "GNU coreutils cp not installed"
+elif [ -z "$SRC" ]; then
+    sk "no fakefs path given (pass one as \$1, e.g. /var/minis/shared/doc.txt)"
+elif [ ! -f "$SRC" ]; then
+    sk "fakefs path $SRC does not exist"
+else
+    rm -f /tmp/regress_out.txt
+    out=$($CP -v "$SRC" /tmp/regress_out.txt 2>&1)
+    rc=$?
+    echo "  cp: $out"
+    [ "$rc" = "0" ] && ok "cp out of fakefs exits 0" \
+                    || no "cp out of fakefs exits 0 (rc=$rc)"
+    # The st_dev mismatch made GNU cp report exactly this and skip the file.
+    case "$out" in
+        *"replaced while being copied"*) no "no 'replaced while being copied'" ;;
+        *) ok "no 'replaced while being copied'" ;;
+    esac
+    if [ -s /tmp/regress_out.txt ]; then
+        ok "copied file is non-empty"
+    else
+        no "copied file is non-empty"
+    fi
+    rm -f /tmp/regress_out.txt
+fi
+
+echo ""
+echo "================ RESULT ================"
+echo "  PASS: $pass    FAIL: $fail    SKIP: $skip"
+[ "$fail" = "0" ]

--- a/tests/regress/regress_syscall.c
+++ b/tests/regress/regress_syscall.c
@@ -1,0 +1,484 @@
+// Regression tests for the fs/wait syscall fixes landed on fix/ish-issue-batch.
+//
+// Each block below pins the observable behaviour of one bug so a future change
+// that reintroduces it fails here instead of in a user's shell. The comment on
+// each block records what the bug actually looked like before the fix.
+//
+// Build for the guest (static, so no rootfs libc is required):
+//   aarch64-linux-musl-gcc -static -O0 -o regress_syscall regress_syscall.c
+// Run inside iSH:
+//   ish -r <rootfs> /tmp/regress_syscall
+//
+// Exit status is 0 when every case passes, 1 otherwise. See tests/regress/run.sh.
+
+#define _GNU_SOURCE
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+static int pass, fail;
+
+static void check(int ok, const char *what) {
+    if (ok) {
+        pass++;
+        printf("  PASS  %s\n", what);
+    } else {
+        fail++;
+        printf("  FAIL  %s   (errno=%d %s)\n", what, errno, strerror(errno));
+    }
+}
+
+static void section(const char *title) {
+    printf("\n=== %s ===\n", title);
+}
+
+static double now_sec(void) {
+    struct timespec t;
+    clock_gettime(CLOCK_MONOTONIC, &t);
+    return t.tv_sec + t.tv_nsec / 1e9;
+}
+
+static void nap(double seconds) {
+    struct timespec t = {(time_t)seconds, (long)((seconds - (int)seconds) * 1e9)};
+    nanosleep(&t, NULL);
+}
+
+// Burn CPU rather than sleeping, so the child is genuinely running (this is
+// what cc1 does, and it is the shape that triggered the waitpid bug).
+static void burn(double seconds) {
+    double t0 = now_sec();
+    volatile unsigned x = 0;
+    while (now_sec() - t0 < seconds)
+        for (int i = 0; i < 200000; i++)
+            x += i;
+}
+
+// ---------------------------------------------------------------------------
+// #30 — O_DIRECTORY carried the x86 value (1<<16) instead of aarch64's 0x4000,
+// so the ENOTDIR check in generic_openat() never fired for any guest, and
+// 1<<16 (arm64's O_DIRECT) was misread as O_DIRECTORY. GNU cp probes its
+// destination with open(dst, O_PATH|O_DIRECTORY); the bogus success made it
+// treat an existing regular file as a directory and fail with
+// "cannot create regular file '<dst>/<src>': Not a directory".
+// ---------------------------------------------------------------------------
+static void test_o_directory(const char *file, const char *dir) {
+    section("#30 O_DIRECTORY flag value");
+
+    errno = 0;
+    int fd = open(file, O_RDONLY | O_DIRECTORY);
+    check(fd < 0 && errno == ENOTDIR, "open(regular file, O_DIRECTORY) -> ENOTDIR");
+    if (fd >= 0)
+        close(fd);
+
+    errno = 0;
+    fd = open(file, O_PATH | O_DIRECTORY);
+    check(fd < 0 && errno == ENOTDIR, "open(regular file, O_PATH|O_DIRECTORY) -> ENOTDIR");
+    if (fd >= 0)
+        close(fd);
+
+    // Guard the other direction: the fix must not break real directories.
+    fd = open(dir, O_RDONLY | O_DIRECTORY);
+    check(fd >= 0, "open(directory, O_DIRECTORY) still succeeds");
+    if (fd >= 0)
+        close(fd);
+
+    DIR *dp = opendir(dir);
+    check(dp != NULL, "opendir(directory) still succeeds");
+    if (dp != NULL) {
+        int entries = 0;
+        while (readdir(dp) != NULL)
+            entries++;
+        check(entries > 0, "readdir() returns entries");
+        closedir(dp);
+    }
+
+    errno = 0;
+    fd = open(dir, O_WRONLY);
+    check(fd < 0 && errno == EISDIR, "open(directory, O_WRONLY) -> EISDIR");
+    if (fd >= 0)
+        close(fd);
+
+    // 1<<16 is O_DIRECT on aarch64. It must not be mistaken for O_DIRECTORY.
+    errno = 0;
+    fd = open(file, O_RDONLY | O_DIRECT);
+    check(fd >= 0, "open(regular file, O_DIRECT) succeeds (not read as O_DIRECTORY)");
+    if (fd >= 0)
+        close(fd);
+
+    check(O_DIRECTORY == 0x4000, "guest O_DIRECTORY == 0x4000 (aarch64 ABI)");
+    check((O_DIRECTORY & O_DIRECT) == 0, "O_DIRECTORY does not overlap O_DIRECT");
+    check((O_DIRECTORY & O_NOFOLLOW) == 0, "O_DIRECTORY does not overlap O_NOFOLLOW");
+    check((O_DIRECTORY & O_PATH) == 0, "O_DIRECTORY does not overlap O_PATH");
+}
+
+// ---------------------------------------------------------------------------
+// #30 follow-up — O_NOFOLLOW was translated to the host open(), but
+// generic_openat() resolves the final path component itself before the
+// filesystem's open() runs, so the host flag was a no-op and
+// open(symlink, O_NOFOLLOW) wrongly returned an fd to the link target.
+// ---------------------------------------------------------------------------
+static void test_o_nofollow(const char *file, const char *link) {
+    section("#30 O_NOFOLLOW honored during path resolution");
+
+    unlink(link);
+    if (symlink(file, link) != 0) {
+        printf("  SKIP  cannot create symlink %s: %s\n", link, strerror(errno));
+        return;
+    }
+
+    errno = 0;
+    int fd = open(link, O_RDONLY | O_NOFOLLOW);
+    check(fd < 0 && errno == ELOOP, "open(symlink, O_NOFOLLOW) -> ELOOP");
+    if (fd >= 0)
+        close(fd);
+
+    fd = open(file, O_RDONLY | O_NOFOLLOW);
+    check(fd >= 0, "open(regular file, O_NOFOLLOW) still succeeds");
+    if (fd >= 0)
+        close(fd);
+
+    // Without O_NOFOLLOW the symlink must still resolve.
+    fd = open(link, O_RDONLY);
+    check(fd >= 0, "open(symlink) without O_NOFOLLOW still follows");
+    if (fd >= 0)
+        close(fd);
+
+    unlink(link);
+}
+
+// ---------------------------------------------------------------------------
+// #31 — fakefs_stat()'s hook-routed branch memset the statbuf and then filled
+// fields by hand, but never set dev (nor nlink/blksize). fstat() went through
+// realfs/copy_stat and did set it, so stat() and fstat() on one file reported
+// the same inode with different st_dev. GNU coreutils' psame_inode() reads
+// that as "the file was replaced while being copied" and cp refuses to copy.
+//
+// Runs against whatever path it is given, so it is meaningful on a plain
+// rootfs and on a fakefs mount point alike.
+// ---------------------------------------------------------------------------
+static void test_stat_fstat_agreement(const char *path) {
+    section("#31 stat/fstat agreement (psame_inode)");
+    printf("  path: %s\n", path);
+
+    struct stat s, f;
+    if (stat(path, &s) != 0) {
+        printf("  SKIP  stat(%s): %s\n", path, strerror(errno));
+        return;
+    }
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        printf("  SKIP  open(%s): %s\n", path, strerror(errno));
+        return;
+    }
+    if (fstat(fd, &f) != 0) {
+        printf("  SKIP  fstat(%s): %s\n", path, strerror(errno));
+        close(fd);
+        return;
+    }
+
+    check(s.st_dev == f.st_dev, "stat.st_dev == fstat.st_dev");
+    check(s.st_ino == f.st_ino, "stat.st_ino == fstat.st_ino");
+    check(s.st_dev != 0, "stat.st_dev != 0");
+    check(s.st_nlink > 0, "stat.st_nlink > 0 (0 reads as an unlinked file)");
+    check(s.st_blksize > 0, "stat.st_blksize > 0 (0 breaks cp's buffer sizing)");
+    // Fields that were already correct before the fix must stay correct.
+    check(s.st_size == f.st_size, "stat.st_size == fstat.st_size");
+    check(s.st_mode == f.st_mode, "stat.st_mode == fstat.st_mode");
+    check(s.st_mtime == f.st_mtime, "stat.st_mtime == fstat.st_mtime");
+    close(fd);
+}
+
+// ---------------------------------------------------------------------------
+// #29 — do_wait() waits with a 1-second bounded timeout (a workaround for
+// macOS condvars). It tested `if (wait_for(...))`, which is true for both
+// _EINTR and _ETIMEDOUT, so every expiry of that internal timeout was
+// reported to the guest as a signal and waitpid returned EINTR. Any child
+// running longer than a second broke its parent; gcc died with
+// "failed to get exit status: Interrupted system call" at ~1.01s.
+// ---------------------------------------------------------------------------
+static void test_waitpid_across_timeout(void) {
+    section("#29 waitpid across the 1s internal timeout");
+
+    // Straddle the boundary: the bug appears the moment a child outlives it.
+    static const double points[] = {0.2, 0.9, 1.0, 1.1, 1.5, 2.0};
+    int bad = 0;
+    for (unsigned i = 0; i < sizeof(points) / sizeof(points[0]); i++) {
+        pid_t p = fork();
+        if (p == 0) {
+            // Alternate sleeping and burning so both blocked and runnable
+            // children are covered.
+            if (i % 2)
+                burn(points[i]);
+            else
+                nap(points[i]);
+            _exit(40 + i);
+        }
+        int st = 0;
+        errno = 0;
+        pid_t r = waitpid(p, &st, 0);
+        int ok = (r == p && WIFEXITED(st) && WEXITSTATUS(st) == (int)(40 + i));
+        if (!ok) {
+            bad++;
+            printf("  child %.1fs -> waitpid=%d errno=%d(%s) exited=%d code=%d\n",
+                   points[i], (int)r, errno, r < 0 ? strerror(errno) : "-",
+                   WIFEXITED(st), WIFEXITED(st) ? WEXITSTATUS(st) : -1);
+        }
+    }
+    check(bad == 0, "children at 0.2/0.9/1.0/1.1/1.5/2.0s all reaped, no EINTR");
+
+    // The zombie must actually be gone once waitpid returns.
+    pid_t p = fork();
+    if (p == 0) {
+        nap(1.2);
+        _exit(44);
+    }
+    int st = 0;
+    check(waitpid(p, &st, 0) == p && WEXITSTATUS(st) == 44, "slow child reaped");
+    errno = 0;
+    check(waitpid(p, &st, WNOHANG) < 0 && errno == ECHILD,
+          "no leftover zombie (second wait -> ECHILD)");
+
+    // Several concurrent slow children, reaped through wait().
+    pid_t kids[3];
+    for (int i = 0; i < 3; i++) {
+        kids[i] = fork();
+        if (kids[i] == 0) {
+            burn(1.1 + 0.2 * i);
+            _exit(50 + i);
+        }
+    }
+    int reaped = 0;
+    for (int i = 0; i < 3; i++) {
+        int s2;
+        pid_t r = wait(&s2);
+        if (r > 0 && WIFEXITED(s2) && WEXITSTATUS(s2) >= 50 && WEXITSTATUS(s2) <= 52)
+            reaped++;
+    }
+    check(reaped == 3, "3 concurrent slow children all reaped via wait()");
+    errno = 0;
+    check(wait(&st) < 0 && errno == ECHILD, "wait() -> ECHILD when no children remain");
+}
+
+// ---------------------------------------------------------------------------
+// A real signal must still interrupt waitpid. The #29 fix narrows got_signal
+// to _EINTR only, so this guards against over-correcting it away.
+// ---------------------------------------------------------------------------
+static volatile sig_atomic_t handler_ran;
+static void on_usr1(int sig) { (void)sig; handler_ran = 1; }
+
+static void test_signal_still_interrupts(void) {
+    section("#29 real signals still interrupt waitpid");
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = on_usr1;
+    sigaction(SIGUSR1, &sa, NULL);
+    handler_ran = 0;
+
+    pid_t child = fork();
+    if (child == 0) {
+        nap(4);
+        _exit(7);
+    }
+    pid_t killer = fork();
+    if (killer == 0) {
+        nap(0.3);
+        kill(getppid(), SIGUSR1);
+        _exit(0);
+    }
+
+    double t0 = now_sec();
+    int st = 0;
+    errno = 0;
+    pid_t r = waitpid(child, &st, 0);
+    double elapsed = now_sec() - t0;
+
+    check(r < 0 && errno == EINTR, "SIGUSR1 during waitpid -> EINTR");
+    check(handler_ran == 1, "signal handler ran");
+    // If this fires at ~1s it means the internal timeout was misreported again.
+    check(elapsed < 1.0, "interrupted at the signal, not at the 1s timeout");
+    check(waitpid(child, &st, 0) == child && WEXITSTATUS(st) == 7,
+          "child still reapable after EINTR");
+    waitpid(killer, NULL, 0);
+}
+
+// ---------------------------------------------------------------------------
+// waitid siginfo — do_wait() produces the raw wait(2) status word, which is
+// what wait4 wants. sys_waitid handed that straight to userspace instead of
+// decoding it, so si_status was 7936 for exit(31) (31<<8) and si_code was
+// always 0, leaving a killed child indistinguishable from an exited one.
+// si_uid was never assigned at all on the wait path.
+// ---------------------------------------------------------------------------
+static void test_waitid_siginfo(void) {
+    section("waitid si_status / si_code / si_uid");
+
+    uid_t me = getuid();
+
+    // exit(N) -> CLD_EXITED / N, including both ends of the byte.
+    static const int codes[] = {0, 31, 255};
+    for (unsigned i = 0; i < sizeof(codes) / sizeof(codes[0]); i++) {
+        pid_t p = fork();
+        if (p == 0)
+            _exit(codes[i]);
+        siginfo_t si;
+        memset(&si, 0, sizeof si);
+        int r = waitid(P_PID, p, &si, WEXITED);
+        char msg[96];
+        snprintf(msg, sizeof msg, "exit(%d) -> CLD_EXITED, si_status=%d", codes[i], codes[i]);
+        check(r == 0 && si.si_code == CLD_EXITED && si.si_status == codes[i], msg);
+        if (i == 1) {
+            check(si.si_signo == SIGCHLD, "si_signo == SIGCHLD");
+            check(si.si_pid == p, "si_pid == child pid");
+            check(si.si_uid == me, "si_uid == child uid");
+        }
+    }
+
+    // Killed by a signal -> CLD_KILLED / signal number.
+    static const int sigs[] = {SIGKILL, SIGTERM};
+    for (unsigned i = 0; i < sizeof(sigs) / sizeof(sigs[0]); i++) {
+        pid_t p = fork();
+        if (p == 0) {
+            nap(10);
+            _exit(0);
+        }
+        nap(0.3);
+        kill(p, sigs[i]);
+        siginfo_t si;
+        memset(&si, 0, sizeof si);
+        int r = waitid(P_PID, p, &si, WEXITED);
+        char msg[96];
+        snprintf(msg, sizeof msg, "killed by %d -> CLD_KILLED, si_status=%d", sigs[i], sigs[i]);
+        check(r == 0 && si.si_code == CLD_KILLED && si.si_status == sigs[i], msg);
+        if (i == 0)
+            check(si.si_uid == me, "si_uid set on CLD_KILLED too");
+    }
+
+    // Stopped -> CLD_STOPPED / stopping signal.
+    {
+        pid_t p = fork();
+        if (p == 0) {
+            nap(10);
+            _exit(0);
+        }
+        nap(0.3);
+        kill(p, SIGSTOP);
+        siginfo_t si;
+        memset(&si, 0, sizeof si);
+        int r = waitid(P_PID, p, &si, WSTOPPED);
+        check(r == 0 && si.si_code == CLD_STOPPED && si.si_status == SIGSTOP,
+              "SIGSTOP -> CLD_STOPPED, si_status=SIGSTOP");
+        kill(p, SIGCONT);
+        kill(p, SIGKILL);
+        siginfo_t reap;
+        waitid(P_PID, p, &reap, WEXITED);
+    }
+
+    // A child that drops privileges must report its own uid, not the parent's.
+    // This is the only case that can distinguish the si_uid bug, since
+    // everything else here runs as a single uid.
+    {
+        pid_t p = fork();
+        if (p == 0) {
+            if (setuid(1000) != 0)
+                _exit(99);
+            _exit(12);
+        }
+        siginfo_t si;
+        memset(&si, 0, sizeof si);
+        int r = waitid(P_PID, p, &si, WEXITED);
+        if (r == 0 && si.si_status == 99) {
+            printf("  SKIP  setuid(1000) not permitted here; cannot test uid change\n");
+        } else {
+            check(r == 0 && si.si_status == 12, "child reached exit(12) after setuid(1000)");
+            check(si.si_uid == 1000, "si_uid == 1000 (child's uid, not the parent's)");
+        }
+    }
+
+    // WNOHANG with nothing ready must not report a scanned candidate's uid.
+    {
+        pid_t p = fork();
+        if (p == 0) {
+            nap(1.0);
+            _exit(13);
+        }
+        nap(0.2);
+        siginfo_t si;
+        memset(&si, 0, sizeof si);
+        int r = waitid(P_PID, p, &si, WEXITED | WNOHANG);
+        check(r == 0 && si.si_pid == 0, "WNOHANG reports si_pid=0 while the child runs");
+        check(si.si_uid == 0, "WNOHANG leaves si_uid=0 (no stale uid)");
+        siginfo_t reap;
+        waitid(P_PID, p, &reap, WEXITED);
+    }
+
+    // wait4/waitpid must keep seeing the *raw* encoding — only waitid decodes.
+    {
+        pid_t p = fork();
+        if (p == 0)
+            _exit(31);
+        int st = 0;
+        pid_t r = waitpid(p, &st, 0);
+        check(r == p && WIFEXITED(st) && WEXITSTATUS(st) == 31,
+              "waitpid still sees raw status (WIFEXITED/WEXITSTATUS)");
+
+        p = fork();
+        if (p == 0) {
+            nap(10);
+            _exit(0);
+        }
+        nap(0.3);
+        kill(p, SIGKILL);
+        st = 0;
+        r = waitpid(p, &st, 0);
+        check(r == p && WIFSIGNALED(st) && WTERMSIG(st) == SIGKILL,
+              "waitpid still sees raw status (WIFSIGNALED/WTERMSIG)");
+    }
+}
+
+int main(int argc, char **argv) {
+    // Optional extra path to check stat/fstat on, e.g. a fakefs mount point.
+    const char *extra_path = argc > 1 ? argv[1] : NULL;
+
+    const char *file = "/tmp/regress_file.txt";
+    const char *dir = "/tmp/regress_dir";
+    const char *link = "/tmp/regress_link";
+
+    unlink(file);
+    unlink(link);
+    rmdir(dir);
+    int fd = open(file, O_CREAT | O_RDWR, 0644);
+    if (fd < 0) {
+        fprintf(stderr, "setup: cannot create %s: %s\n", file, strerror(errno));
+        return 2;
+    }
+    write(fd, "regression\n", 11);
+    close(fd);
+    if (mkdir(dir, 0755) != 0 && errno != EEXIST) {
+        fprintf(stderr, "setup: cannot create %s: %s\n", dir, strerror(errno));
+        return 2;
+    }
+
+    test_o_directory(file, dir);
+    test_o_nofollow(file, link);
+    test_stat_fstat_agreement(file);
+    if (extra_path != NULL)
+        test_stat_fstat_agreement(extra_path);
+    test_waitpid_across_timeout();
+    test_signal_still_interrupts();
+    test_waitid_siginfo();
+
+    printf("\n================ RESULT ================\n");
+    printf("  PASS: %d    FAIL: %d\n", pass, fail);
+
+    unlink(file);
+    unlink(link);
+    rmdir(dir);
+    return fail ? 1 : 0;
+}

--- a/tests/regress/run.sh
+++ b/tests/regress/run.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Build and run the fs/wait syscall regression tests inside iSH.
+#
+# These pin the behaviour of five fixes so a regression fails here rather than
+# in a user's shell:
+#   #30  O_DIRECTORY flag value + O_NOFOLLOW honored at path resolution
+#   #31  fakefs stat/fstat st_dev (nlink, blksize) agreement
+#   #29  waitpid not reporting its internal 1s timeout as EINTR
+#        waitid si_status/si_code decoding
+#        waitid si_uid
+#
+# Usage:
+#   tests/regress/run.sh [-i <ish binary>] [-r <rootfs>] [-f <fakefs path>]
+#
+#   -i  iSH binary to test. Default: the first of build-arm64-release/ish,
+#       build/ish that exists.
+#   -r  rootfs to run against, passed to iSH as -r. Default alpine-arm64-321.
+#   -f  a file under a fakefs mount point (e.g. /var/minis/shared/doc.txt) to
+#       additionally check stat/fstat agreement on. Only meaningful when the
+#       rootfs is mounted with -f and a path-translate hook is installed, so it
+#       is optional; without it the #31 assertions still run against the rootfs.
+#
+# The guest test binary is built with a cross-compiler (aarch64-linux-musl-gcc
+# by default, override with $CC_GUEST). If none is available the script skips
+# rather than failing, since the toolchain is not part of the repo.
+
+set -u
+cd "$(dirname "$0")/../.."
+
+ISH=""
+ROOTFS="alpine-arm64-321"
+FAKEFS_PATH=""
+MOUNT_FLAG="-r"
+
+while getopts "i:r:f:m:h" opt; do
+    case $opt in
+        i) ISH="$OPTARG" ;;
+        r) ROOTFS="$OPTARG" ;;
+        f) FAKEFS_PATH="$OPTARG" ;;
+        m) MOUNT_FLAG="$OPTARG" ;;
+        h) sed -n '2,26p' "$0"; exit 0 ;;
+        *) exit 2 ;;
+    esac
+done
+
+if [ -z "$ISH" ]; then
+    for cand in build-arm64-release/ish build/ish; do
+        if [ -x "$cand" ]; then ISH="$cand"; break; fi
+    done
+fi
+if [ -z "$ISH" ] || [ ! -x "$ISH" ]; then
+    echo "no iSH binary found; build one or pass -i <path>" >&2
+    exit 2
+fi
+if [ ! -d "$ROOTFS" ]; then
+    echo "rootfs $ROOTFS not found; pass -r <path>" >&2
+    exit 2
+fi
+
+CC_GUEST="${CC_GUEST:-aarch64-linux-musl-gcc}"
+if ! command -v "$CC_GUEST" >/dev/null 2>&1; then
+    echo "SKIP: no guest cross-compiler ($CC_GUEST) available." >&2
+    echo "      Install one or set CC_GUEST to build tests/regress/regress_syscall.c." >&2
+    exit 0
+fi
+
+SRC=tests/regress/regress_syscall.c
+# With -f the guest's / lives under <rootfs>/data; with -r it is <rootfs> itself.
+GUEST_ROOT="$ROOTFS"
+if [ "$MOUNT_FLAG" = "-f" ]; then
+    GUEST_ROOT="$ROOTFS/data"
+fi
+BIN="$GUEST_ROOT/tmp/regress_syscall"
+mkdir -p "$GUEST_ROOT/tmp"
+echo "building $SRC with $CC_GUEST"
+if ! "$CC_GUEST" -static -O0 -Wall -o "$BIN" "$SRC"; then
+    echo "failed to build $SRC" >&2
+    exit 1
+fi
+cp tests/regress/regress_cp.sh "$GUEST_ROOT/tmp/regress_cp.sh"
+
+# A fakefs keeps its own metadata in meta.db, so files dropped straight into
+# data/ are invisible to the guest. Register them by copying through the guest
+# itself; the shell script is small enough for this to be cheap, but the test
+# binary is not, so -f mode runs only the cp cases and expects the syscall
+# binary to be run separately under -r (where every one of these assertions is
+# equally valid -- none of them depend on the mount type).
+if [ "$MOUNT_FLAG" = "-f" ]; then
+    rm -f "$BIN"
+    b64_sh=$(base64 < tests/regress/regress_cp.sh | tr -d '\n')
+    rm -f "$GUEST_ROOT/tmp/regress_cp.sh"
+    if ! "$ISH" "$MOUNT_FLAG" "$ROOTFS" /bin/sh -c \
+        "printf %s '$b64_sh' | base64 -d > /tmp/regress_cp.sh"; then
+        echo "failed to stage regress_cp.sh into the fakefs" >&2
+        exit 1
+    fi
+fi
+
+status=0
+
+if [ "$MOUNT_FLAG" = "-f" ]; then
+    echo
+    echo "########## syscall regressions ##########"
+    echo "  SKIP  staging a static binary into a fakefs is impractical;"
+    echo "        run these with -r <rootfs> (assertions are mount-independent)."
+else
+    echo
+    echo "########## syscall regressions ($ISH $MOUNT_FLAG $ROOTFS) ##########"
+    "$ISH" "$MOUNT_FLAG" "$ROOTFS" /tmp/regress_syscall ${FAKEFS_PATH:+"$FAKEFS_PATH"} || status=1
+fi
+
+echo
+echo "########## cp regressions ##########"
+"$ISH" "$MOUNT_FLAG" "$ROOTFS" /bin/sh /tmp/regress_cp.sh ${FAKEFS_PATH:+"$FAKEFS_PATH"} || status=1
+
+rm -f "$BIN" "$GUEST_ROOT/tmp/regress_cp.sh"
+
+echo
+if [ "$status" = "0" ]; then
+    echo "regress: all cases passed"
+else
+    echo "regress: FAILURES (see above)"
+fi
+exit $status


### PR DESCRIPTION
## Summary

A batch of arm64 kernel/fs correctness fixes for the iSH fork, each pinned with a regression test. All commits are already on `fix/ish-issue-batch`; this PR merges them into `master`.

The changes fall into four areas:

- **ASIMD lane conversions** — implement `FCVTN` / `FCVTL` / `FCVTXN` (float↔half / narrow) gadgets, previously unhandled (#22). New `asbestos/guest-arm64/gadgets-aarch64/math.S` + `gen.c` wiring.
- **wait/waitid semantics** — treat `waitpid`'s internal timeout as a retry rather than a spurious signal (fixes EINTR misjudgment, #29); decode `si_status` / `si_code` and fill `si_uid` for `waitid`.
- **filesystem** — honor `O_NOFOLLOW` in `path_normalize` instead of at the host `open` (#30); use the aarch64 `O_DIRECTORY` value so `cp` over an existing file works (#30); set `dev`/`nlink`/`blksize` on hook-routed `stat` so `cp` no longer reports "replaced while being copied" (#31).
- **kernel robustness** — release `pids_lock` on the `task_create_` malloc-failure path. Returning while still holding the lock turned an OOM `fork` into a total kernel freeze (every later `task_create_`, `pid_get_task`, and signal delivery blocks on the lock forever); the fix also rolls back the pid slot claimed just above.

## Testing

New regression coverage under `tests/regress/`:
- `regress_asimd_fcvt.{S,c}` — the FCVT lane conversions
- `regress_cp.sh` — the `cp`-over-existing / stat-during-copy fs fixes
- `regress_syscall.c` — waitpid/waitid status decoding and timeout behavior
- `run.sh` + `README.md` — harness and scenario notes
- `bench-legacy/scripts/test_200_core_software.sh` — scenario-level pass over the 263-package suite

## Notes

- Base is `master` (this repo has no `main`; `master` is the fork's default branch).
- Upstream is `ish-app/ish`; these fixes are specific to the OpenMinis arm64 fork and are not being sent upstream here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
